### PR TITLE
Bumping base upper bounds to support ghc 8.2

### DIFF
--- a/pqueue.cabal
+++ b/pqueue.cabal
@@ -26,7 +26,7 @@ Library {
   default-language:
     Haskell2010
   build-depends:
-  { base >= 4 && < 4.10
+  { base >= 4 && < 4.11
   , deepseq >= 1.3 && < 1.5
   }
   exposed-modules:
@@ -62,7 +62,7 @@ Test-Suite test
   Type: exitcode-stdio-1.0
   Main-Is: PQueueTests.hs
   Build-Depends:
-  { base >= 4 && < 4.10
+  { base >= 4 && < 4.11
   , deepseq >= 1.3 && < 1.5
   , QuickCheck >=2.5 && <3
   }


### PR DESCRIPTION
Package seems to compile fine with base-4.10 :)  Just bumping the upper bound to 4.11 so it can be built with ghc 8.2, if you wanted!

Thanks for the great package!