### PR TITLE
Improve worst-case bounds

### DIFF
--- a/pqueue.cabal
+++ b/pqueue.cabal
@@ -43,6 +43,10 @@ library
     default-extensions: DeriveDataTypeable
   }
   ghc-options: {
+    -- We currently need -fspec-constr to get GHC to compile conversions
+    -- from lists well. We could (and probably should) write those a
+    -- bit differently so we won't need it.
+    -fspec-constr
     -fdicts-strict
     -Wall
     -fno-warn-inline-rule-shadowing

--- a/src/Data/PQueue/Max.hs
+++ b/src/Data/PQueue/Max.hs
@@ -16,8 +16,6 @@
 -- some operations. These bounds hold even in a persistent (shared) setting.
 --
 -- This implementation is based on a binomial heap augmented with a global root.
--- The spine of the heap is maintained lazily. To force the spine of the heap,
--- use 'seqSpine'.
 --
 -- This implementation does not guarantee stable behavior.
 --
@@ -335,12 +333,18 @@ fromDescList = MaxQ . Min.fromAscList . map Down
 {-# INLINE fromList #-}
 -- | /O(n log n)/. Constructs a priority queue from an unordered list.
 fromList :: Ord a => [a] -> MaxQueue a
-fromList = foldr insert empty
+fromList = MaxQ . Min.fromList . map Down
 
 -- | /O(n)/. Constructs a priority queue from the keys of a 'Prio.MaxPQueue'.
 keysQueue :: Prio.MaxPQueue k a -> MaxQueue k
 keysQueue (Prio.MaxPQ q) = MaxQ (Min.keysQueue q)
 
--- | /O(log n)/. Forces the spine of the heap.
+-- | /O(log n)/. @seqSpine q r@ forces the spine of @q@ and returns @r@.
+--
+-- Note: The spine of a 'MaxQueue' is stored somewhat lazily. Most operations
+-- take great care to prevent chains of thunks from accumulating along the
+-- spine to the detriment of performance. However, 'mapU' can leave expensive
+-- thunks in the structure and repeated applications of that function can
+-- create thunk chains.
 seqSpine :: MaxQueue a -> b -> b
 seqSpine (MaxQ q) = Min.seqSpine q

--- a/src/Data/PQueue/Min.hs
+++ b/src/Data/PQueue/Min.hs
@@ -268,10 +268,10 @@ foldlDesc = foldrAsc . flip
 {-# INLINE fromList #-}
 -- | /O(n)/. Constructs a priority queue from an unordered list.
 fromList :: Ord a => [a] -> MinQueue a
-fromList = foldr insert empty
+fromList = foldl' (flip insert) empty
 
 {-# RULES
-  "fromList" fromList = foldr insert empty;
+  "fromList" fromList = foldl' (flip insert) empty;
   "fromAscList" fromAscList = foldr insertMinQ empty;
   #-}
 

--- a/src/Data/PQueue/Min.hs
+++ b/src/Data/PQueue/Min.hs
@@ -17,8 +17,6 @@
 -- some operations. These bounds hold even in a persistent (shared) setting.
 --
 -- This implementation is based on a binomial heap augmented with a global root.
--- The spine of the heap is maintained lazily. To force the spine of the heap,
--- use 'seqSpine'.
 --
 -- This implementation does not guarantee stable behavior.
 --
@@ -265,24 +263,22 @@ foldrDesc = foldlAsc . flip
 foldlDesc :: Ord a => (b -> a -> b) -> b -> MinQueue a -> b
 foldlDesc = foldrAsc . flip
 
-{-# INLINE fromList #-}
--- | /O(n)/. Constructs a priority queue from an unordered list.
-fromList :: Ord a => [a] -> MinQueue a
-fromList = foldl' (flip insert) empty
-
-{-# RULES
-  "fromList" fromList = foldl' (flip insert) empty;
-  "fromAscList" fromAscList = foldr insertMinQ empty;
-  #-}
-
 {-# INLINE fromAscList #-}
 -- | /O(n)/. Constructs a priority queue from an ascending list. /Warning/: Does not check the precondition.
+--
+-- Performance note: Code using this function in a performance-sensitive context
+-- with an argument that is a "good producer" for list fusion should be compiled
+-- with @-fspec-constr@ or @-O2@. For example, @fromAscList . map f@ needs one
+-- of these options for best results.
 fromAscList :: [a] -> MinQueue a
-fromAscList = foldr insertMinQ empty
+-- We apply an explicit argument to get foldl' to inline.
+fromAscList xs = foldl' (flip insertMaxQ') empty xs
 
+{-# INLINE fromDescList #-}
 -- | /O(n)/. Constructs a priority queue from an descending list. /Warning/: Does not check the precondition.
 fromDescList :: [a] -> MinQueue a
-fromDescList = foldl' (flip insertMinQ) empty
+-- We apply an explicit argument to get foldl' to inline.
+fromDescList xs = foldl' (flip insertMinQ') empty xs
 
 -- | Maps a function over the elements of the queue, ignoring order. This function is only safe if the function is monotonic.
 -- This function /does not/ check the precondition.

--- a/src/Data/PQueue/Prio/Max.hs
+++ b/src/Data/PQueue/Prio/Max.hs
@@ -18,8 +18,6 @@
 -- bound is also specified; these bounds do not hold in a persistent context.
 --
 -- This implementation is based on a binomial heap augmented with a global root.
--- The spine of the heap is maintained lazily. To force the spine of the heap,
--- use 'seqSpine'.
 --
 -- We do not guarantee stable behavior.
 -- Ties are broken arbitrarily -- that is, if @k1 <= k2@ and @k2 <= k1@, then there
@@ -471,6 +469,12 @@ assocsU = toListU
 toListU :: MaxPQueue k a -> [(k, a)]
 toListU (MaxPQ q) = fmap (first' unDown) (Q.toListU q)
 
--- | /O(log n)/. Analogous to @deepseq@ in the @deepseq@ package, but only forces the spine of the binomial heap.
+-- | /O(log n)/. @seqSpine q r@ forces the spine of @q@ and returns @r@.
+--
+-- Note: The spine of a 'MaxPQueue' is stored somewhat lazily. Most operations
+-- take great care to prevent chains of thunks from accumulating along the
+-- spine to the detriment of performance. However, 'mapKeysMonotonic' can leave
+-- expensive thunks in the structure and repeated applications of that function
+-- can create thunk chains.
 seqSpine :: MaxPQueue k a -> b -> b
 seqSpine (MaxPQ q) = Q.seqSpine q

--- a/src/Data/PQueue/Prio/Min.hs
+++ b/src/Data/PQueue/Prio/Min.hs
@@ -18,8 +18,6 @@
 -- bound is also specified; these bounds do not hold in a persistent context.
 --
 -- This implementation is based on a binomial heap augmented with a global root.
--- The spine of the heap is maintained lazily. To force the spine of the heap,
--- use 'seqSpine'.
 --
 -- We do not guarantee stable behavior.
 -- Ties are broken arbitrarily -- that is, if @k1 <= k2@ and @k2 <= k1@, then there
@@ -176,7 +174,7 @@ instance (Read k, Read a) => Read (MinPQueue k a) where
 
 -- | The union of a list of queues: (@'unions' == 'List.foldl' 'union' 'empty'@).
 unions :: Ord k => [MinPQueue k a] -> MinPQueue k a
-unions = List.foldl union empty
+unions = List.foldl' union empty
 
 -- | /O(1)/. The minimal (key, element) in the queue. Calls 'error' if empty.
 findMin :: MinPQueue k a -> (k, a)
@@ -317,24 +315,15 @@ spanWithKey p q = case minViewWithKey q of
 breakWithKey :: Ord k => (k -> a -> Bool) -> MinPQueue k a -> ([(k, a)], MinPQueue k a)
 breakWithKey p = spanWithKey (not .: p)
 
--- | /O(n)/. Build a priority queue from the list of (key, value) pairs.
-fromList :: Ord k => [(k, a)] -> MinPQueue k a
-fromList = foldr (uncurry' insert) empty
-
 -- | /O(n)/. Build a priority queue from an ascending list of (key, value) pairs. /The precondition is not checked./
 fromAscList :: [(k, a)] -> MinPQueue k a
-fromAscList = foldr (uncurry' insertMin) empty
+{-# INLINE fromAscList #-}
+fromAscList xs = List.foldl' (\q (k, a) -> insertMax' k a q) empty xs
 
 -- | /O(n)/. Build a priority queue from a descending list of (key, value) pairs. /The precondition is not checked./
 fromDescList :: [(k, a)] -> MinPQueue k a
-fromDescList = List.foldl' (\q (k, a) -> insertMin k a q) empty
-
-{-# RULES
-  "fromList/build" forall (g :: forall b . ((k, a) -> b -> b) -> b -> b) .
-    fromList (build g) = g (uncurry' insert) empty;
-  "fromAscList/build" forall (g :: forall b . ((k, a) -> b -> b) -> b -> b) .
-    fromAscList (build g) = g (uncurry' insertMin) empty;
-  #-}
+{-# INLINE fromDescList #-}
+fromDescList xs = List.foldl' (\q (k, a) -> insertMin' k a q) empty xs
 
 {-# INLINE keys #-}
 -- | /O(n log n)/. Return all keys of the queue in ascending order.


### PR DESCRIPTION
Previously, `minView` was amortized `O(log n)` but worst-case `O(n)`.
Improve that to amortized *and* worst-case `O(log n)` (ignoring the
impact of repeated applications of `mapMonotonic`). In informal
testing, these changes lead to large performance improvements.

* Previously, lots of things were suspended that didn't need to be.
  Document the actual laziness requirements with a debit invariant
  and be more eager where allowed.

* Rework `extractBin` to calculate the minimum on the way down instead
  of on the way up. This avoids building a chain of thunks that
  (if forced) actually rebuilds the queue.

I chose to make the internal nodes of the binomial tree quite strict.
For most purposes, this is good. The only downside is that
`mapMonotonic` is now slower, since it cannot be "operationally fused"
with surrounding operations. This doesn't seem like a huge deal,
since I don't imagine mapping over priority queues is something
that happens all that much.

Closes #24 