### PR TITLE
Bump base upper bound to <4.16

### DIFF
--- a/pqueue.cabal
+++ b/pqueue.cabal
@@ -12,7 +12,7 @@ Maintainer:         Lennart Spitzner <hexagoxel@hexagoxel.de>
 Bug-reports:        https://github.com/lspitzner/pqueue/issues
 Build-type:         Simple
 cabal-version:      >= 1.10
-tested-with:        GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.3, GHC == 8.10.1
+tested-with:        GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.3, GHC == 8.10.1, GHC == 9.0.1
 extra-source-files: {
   include/Typeable.h
   CHANGELOG.md
@@ -27,7 +27,7 @@ Library {
   default-language:
     Haskell2010
   build-depends:
-  { base >= 4.8 && < 4.15
+  { base >= 4.8 && < 4.16
   , deepseq >= 1.3 && < 1.5
   }
   exposed-modules:
@@ -62,7 +62,7 @@ Test-Suite test
   Type: exitcode-stdio-1.0
   Main-Is: PQueueTests.hs
   Build-Depends:
-  { base >= 4.8 && < 4.15
+  { base >= 4.8 && < 4.16
   , deepseq >= 1.3 && < 1.5
   , QuickCheck >= 2.5 && < 3
   , pqueue


### PR DESCRIPTION
With this patch, `cabal build -w ghc-9.0.1` works :)