### PR TITLE
Add GitHub CI

### DIFF
--- a/.github/workflows/haskell.yaml
+++ b/.github/workflows/haskell.yaml
@@ -1,0 +1,21 @@
+name: Haskell CI
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ghc: ['7.10.3', '8.0.2', '8.2.2', '8.4.4', '8.6.5', '8.8.4', '8.10.7', '9.0.1', '9.2.1']
+    steps:
+      - uses: actions/checkout@v2
+      - uses: haskell/actions/setup@v1
+        with:
+          ghc-version: ${{ matrix.ghc }}
+      - name: Build
+        run: cabal build
+      - name: Test
+        run: cabal test --test-show-details=direct

--- a/pqueue.cabal
+++ b/pqueue.cabal
@@ -12,7 +12,7 @@ maintainer:         Lennart Spitzner <hexagoxel@hexagoxel.de>
 bug-reports:        https://github.com/lspitzner/pqueue/issues
 build-type:         Simple
 cabal-version:      >= 1.10
-tested-with:        GHC == 8.6.5, GHC == 8.8.4, GHC == 8.10.7, GHC == 9.0.1, GHC == 9.2.1
+tested-with:        GHC == 7.10.3, GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.4, GHC == 8.10.7, GHC == 9.0.1, GHC == 9.2.1
 extra-source-files:
   include/Typeable.h
   CHANGELOG.md


### PR DESCRIPTION
I added GHC versions 7.10.3, 8.0.2, 8.2.2 and 8.4.4 to the `tested-with` section (since we have `base >= 4.8`, so the minimum GHC version is 7.10). The CI tests all versions from the `tested-with` section.

BTW, I suggest merging PRs using "squash and merge", which combines all PR commits into a single one and commits that (without an annoying "Merge pull request" commit).