### PR TITLE
Fix warnings & implement missing method

### DIFF
--- a/src/Data/PQueue/Max.hs
+++ b/src/Data/PQueue/Max.hs
@@ -142,7 +142,10 @@ instance Ord a => Semigroup (MaxQueue a) where
 
 instance Ord a => Monoid (MaxQueue a) where
   mempty = empty
+#if !MIN_VERSION_base(4,11,0)
   mappend = union
+#endif
+  mconcat = unions
 
 -- | /O(1)/. The empty priority queue.
 empty :: MaxQueue a

--- a/src/Data/PQueue/Min.hs
+++ b/src/Data/PQueue/Min.hs
@@ -130,7 +130,9 @@ instance Ord a => Semigroup (MinQueue a) where
 
 instance Ord a => Monoid (MinQueue a) where
   mempty = empty
+#if !MIN_VERSION_base(4,11,0)
   mappend = union
+#endif
   mconcat = unions
 
 -- | /O(1)/. Returns the minimum element. Throws an error on an empty queue.

--- a/src/Data/PQueue/Prio/Max.hs
+++ b/src/Data/PQueue/Prio/Max.hs
@@ -143,7 +143,9 @@ instance Ord k => Semigroup (MaxPQueue k a) where
 
 instance Ord k => Monoid (MaxPQueue k a) where
   mempty = empty
+#if !MIN_VERSION_base(4,11,0)
   mappend = union
+#endif
   mconcat = unions
 
 instance (Ord k, Show k, Show a) => Show (MaxPQueue k a) where

--- a/src/Data/PQueue/Prio/Min.hs
+++ b/src/Data/PQueue/Prio/Min.hs
@@ -149,7 +149,9 @@ instance Ord k => Semigroup (MinPQueue k a) where
 
 instance Ord k => Monoid (MinPQueue k a) where
   mempty = empty
+#if !MIN_VERSION_base(4,11,0)
   mappend = union
+#endif
   mconcat = unions
 
 instance (Ord k, Show k, Show a) => Show (MinPQueue k a) where


### PR DESCRIPTION
Now [-Wnoncanonical-monoid-instances](https://downloads.haskell.org/ghc/latest/docs/html/users_guide/using-warnings.html#ghc-flag--Wnoncanonical-monoid-instances) doesn't complain about `mappend` not being defined as `mappend = (<>)` anymore. Also added missing `mconcat = unions` for `Data.PQueue.Max`.