### PR TITLE
Define stimes

### DIFF
--- a/src/Data/PQueue/Internals.hs
+++ b/src/Data/PQueue/Internals.hs
@@ -45,7 +45,7 @@ module Data.PQueue.Internals (
 import Control.DeepSeq (NFData(rnf), deepseq)
 import Data.Foldable (foldl')
 #if MIN_VERSION_base(4,9,0)
-import Data.Semigroup (Semigroup((<>)))
+import Data.Semigroup (Semigroup(..), stimesMonoid)
 #endif
 
 import qualified Data.PQueue.Prio.Internals as Prio
@@ -746,6 +746,7 @@ instance Read a => Read (MinQueue a) where
 #if MIN_VERSION_base(4,9,0)
 instance Ord a => Semigroup (MinQueue a) where
   (<>) = union
+  stimes = stimesMonoid
 #endif
 
 instance Ord a => Monoid (MinQueue a) where

--- a/src/Data/PQueue/Max.hs
+++ b/src/Data/PQueue/Max.hs
@@ -85,7 +85,7 @@ import Control.DeepSeq (NFData(rnf))
 import Data.Maybe (fromMaybe)
 
 #if MIN_VERSION_base(4,9,0)
-import Data.Semigroup (Semigroup((<>)))
+import Data.Semigroup (Semigroup(..), stimesMonoid)
 #endif
 
 import qualified Data.PQueue.Min as Min
@@ -138,6 +138,7 @@ instance Read a => Read (MaxQueue a) where
 #if MIN_VERSION_base(4,9,0)
 instance Ord a => Semigroup (MaxQueue a) where
   (<>) = union
+  stimes = stimesMonoid
 #endif
 
 instance Ord a => Monoid (MaxQueue a) where

--- a/src/Data/PQueue/Prio/Internals.hs
+++ b/src/Data/PQueue/Prio/Internals.hs
@@ -51,7 +51,7 @@ import Control.DeepSeq (NFData(rnf), deepseq)
 import qualified Data.List as List
 
 #if MIN_VERSION_base(4,9,0)
-import Data.Semigroup (Semigroup((<>)))
+import Data.Semigroup (Semigroup(..), stimesMonoid)
 #else
 import Data.Monoid ((<>))
 #endif
@@ -91,6 +91,7 @@ fromListConstr = mkConstr queueDataType "fromList" [] Prefix
 #if MIN_VERSION_base(4,9,0)
 instance Ord k => Semigroup (MinPQueue k a) where
   (<>) = union
+  stimes = stimesMonoid
 #endif
 
 instance Ord k => Monoid (MinPQueue k a) where

--- a/src/Data/PQueue/Prio/Max/Internals.hs
+++ b/src/Data/PQueue/Prio/Max/Internals.hs
@@ -103,7 +103,7 @@ import qualified Data.PQueue.Prio.Internals as PrioInternals
 import Control.DeepSeq (NFData(rnf))
 
 #if MIN_VERSION_base(4,9,0)
-import Data.Semigroup (Semigroup((<>)))
+import Data.Semigroup (Semigroup(..), stimesMonoid)
 #endif
 
 import Prelude hiding (map, filter, break, span, takeWhile, dropWhile, splitAt, take, drop, (!!), null)
@@ -141,6 +141,7 @@ first' f (a, c) = (f a, c)
 #if MIN_VERSION_base(4,9,0)
 instance Ord k => Semigroup (MaxPQueue k a) where
   (<>) = union
+  stimes = stimesMonoid
 #endif
 
 instance Ord k => Monoid (MaxPQueue k a) where


### PR DESCRIPTION
Use `stimes = stimesMonoid` so that `stimes 0 q` produces
`empty` instead of an error.

Fixes #54