### PR TITLE
Streamline and expand folds

### DIFF
--- a/pqueue.cabal
+++ b/pqueue.cabal
@@ -37,6 +37,7 @@ library
     Data.PQueue.Prio.Internals
     Data.PQueue.Internals
     Data.PQueue.Internals.Down
+    Data.PQueue.Internals.Foldable
     Data.PQueue.Prio.Max.Internals
     Control.Applicative.Identity
   if impl(ghc) {

--- a/src/Data/PQueue/Internals/Down.hs
+++ b/src/Data/PQueue/Internals/Down.hs
@@ -1,8 +1,10 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE BangPatterns #-}
 
 module Data.PQueue.Internals.Down where
 
 import Control.DeepSeq (NFData(rnf))
+import Data.Foldable (Foldable (..))
 
 #if __GLASGOW_HASKELL__
 import Data.Data (Data)
@@ -29,3 +31,4 @@ instance Functor Down where
 instance Foldable Down where
   foldr f z (Down a) = a `f` z
   foldl f z (Down a) = z `f` a
+  foldl' f !z (Down a) = z `f` a

--- a/src/Data/PQueue/Internals/Foldable.hs
+++ b/src/Data/PQueue/Internals/Foldable.hs
@@ -1,0 +1,38 @@
+-- | Writing 'Foldable' instances for non-regular (AKA, nested) types in the
+-- natural manner leads to full `Foldable` dictionaries being constructed on
+-- each recursive call. This is pretty inefficient. It's better to construct
+-- exactly what we need instead.
+module Data.PQueue.Internals.Foldable
+  ( Foldr (..)
+  , Foldl (..)
+  , FoldMap (..)
+  , Foldl' (..)
+  , IFoldr (..)
+  , IFoldl (..)
+  , IFoldMap (..)
+  , IFoldl' (..)
+  ) where
+
+class Foldr t where
+  foldr_ :: (a -> b -> b) -> b -> t a -> b
+
+class IFoldr t where
+  foldrWithKey_ :: (k -> a -> b -> b) -> b -> t k a -> b
+
+class Foldl t where
+  foldl_ :: (b -> a -> b) -> b -> t a -> b
+
+class IFoldl t where
+  foldlWithKey_ :: (b -> k -> a -> b) -> b -> t k a -> b
+
+class FoldMap t where
+  foldMap_ :: Monoid m => (a -> m) -> t a -> m
+
+class IFoldMap t where
+  foldMapWithKey_ :: Monoid m => (k -> a -> m) -> t k a -> m
+
+class Foldl' t where
+  foldl'_ :: (b -> a -> b) -> b -> t a -> b
+
+class IFoldl' t where
+  foldlWithKey'_ :: (b -> k -> a -> b) -> b -> t k a -> b

--- a/src/Data/PQueue/Max.hs
+++ b/src/Data/PQueue/Max.hs
@@ -74,6 +74,8 @@ module Data.PQueue.Max (
   mapU,
   foldrU,
   foldlU,
+  foldlU',
+  foldMapU,
   elemsU,
   toListU,
   -- * Miscellaneous operations
@@ -87,6 +89,8 @@ import Data.Maybe (fromMaybe)
 #if MIN_VERSION_base(4,9,0)
 import Data.Semigroup (Semigroup(..), stimesMonoid)
 #endif
+
+import Data.Foldable (foldl')
 
 import qualified Data.PQueue.Min as Min
 import qualified Data.PQueue.Prio.Max.Internals as Prio
@@ -273,9 +277,17 @@ mapU f (MaxQ q) = MaxQ (Min.mapU (\(Down a) -> Down (f a)) q)
 foldrU :: (a -> b -> b) -> b -> MaxQueue a -> b
 foldrU f z (MaxQ q) = Min.foldrU (flip (foldr f)) z q
 
+-- | /O(n)/. Unordered monoidal fold on a priority queue.
+foldMapU :: Monoid m => (a -> m) -> MaxQueue a -> m
+foldMapU f (MaxQ q) = Min.foldMapU (f . unDown) q
+
 -- | /O(n)/. Unordered left fold on a priority queue.
 foldlU :: (b -> a -> b) -> b -> MaxQueue a -> b
 foldlU f z (MaxQ q) = Min.foldlU (foldl f) z q
+
+-- | /O(n)/. Unordered strict left fold on a priority queue.
+foldlU' :: (b -> a -> b) -> b -> MaxQueue a -> b
+foldlU' f z (MaxQ q) = Min.foldlU' (foldl' f) z q
 
 {-# INLINE elemsU #-}
 -- | Equivalent to 'toListU'.

--- a/src/Data/PQueue/Min.hs
+++ b/src/Data/PQueue/Min.hs
@@ -73,6 +73,8 @@ module Data.PQueue.Min (
   mapU,
   foldrU,
   foldlU,
+  foldlU',
+  foldMapU,
   elemsU,
   toListU,
   -- * Miscellaneous operations

--- a/src/Data/PQueue/Prio/Max.hs
+++ b/src/Data/PQueue/Prio/Max.hs
@@ -99,8 +99,10 @@ module Data.PQueue.Prio.Max (
   -- * Unordered operations
   foldrU,
   foldrWithKeyU,
+  foldMapWithKeyU,
   foldlU,
   foldlWithKeyU,
+  foldlWithKeyU',
   traverseU,
   traverseWithKeyU,
   keysU,

--- a/src/Data/PQueue/Prio/Max/Internals.hs
+++ b/src/Data/PQueue/Prio/Max/Internals.hs
@@ -82,9 +82,12 @@ module Data.PQueue.Prio.Max.Internals (
   toList,
   -- * Unordered operations
   foldrU,
+  foldMapWithKeyU,
   foldrWithKeyU,
   foldlU,
+  foldlU',
   foldlWithKeyU,
+  foldlWithKeyU',
   traverseU,
   traverseWithKeyU,
   keysU,
@@ -464,13 +467,30 @@ foldrU = foldrWithKeyU . const
 foldrWithKeyU :: (k -> a -> b -> b) -> b -> MaxPQueue k a -> b
 foldrWithKeyU f z (MaxPQ q) = Q.foldrWithKeyU (f . unDown) z q
 
--- | /O(n)/. An unordered left fold over the elements of the queue, in no particular order.
+-- | /O(n)/. An unordered monoidal fold over the elements of the queue, in no particular order.
+foldMapWithKeyU :: Monoid m => (k -> a -> m) -> MaxPQueue k a -> m
+foldMapWithKeyU f (MaxPQ q) = Q.foldMapWithKeyU (f . unDown) q
+
+-- | /O(n)/. An unordered left fold over the elements of the queue, in no
+-- particular order.  This is rarely what you want; 'foldrU' and 'foldlU'' are
+-- more likely to perform well.
 foldlU :: (b -> a -> b) -> b -> MaxPQueue k a -> b
 foldlU f = foldlWithKeyU (const . f)
 
--- | /O(n)/. An unordered left fold over the elements of the queue, in no particular order.
+-- | /O(n)/. An unordered strict left fold over the elements of the queue, in no
+-- particular order.
+foldlU' :: (b -> a -> b) -> b -> MaxPQueue k a -> b
+foldlU' f = foldlWithKeyU' (const . f)
+
+-- | /O(n)/. An unordered left fold over the elements of the queue, in no
+-- particular order.  This is rarely what you want; 'foldrWithKeyU' and
+-- 'foldlWithKeyU'' are more likely to perform well.
 foldlWithKeyU :: (b -> k -> a -> b) -> b -> MaxPQueue k a -> b
 foldlWithKeyU f z0 (MaxPQ q) = Q.foldlWithKeyU (\z -> f z . unDown) z0 q
+
+-- | /O(n)/. An unordered left fold over the elements of the queue, in no particular order.
+foldlWithKeyU' :: (b -> k -> a -> b) -> b -> MaxPQueue k a -> b
+foldlWithKeyU' f z0 (MaxPQ q) = Q.foldlWithKeyU' (\z -> f z . unDown) z0 q
 
 -- | /O(n)/. An unordered traversal over a priority queue, in no particular order.
 -- While there is no guarantee in which order the elements are traversed, the resulting

--- a/src/Data/PQueue/Prio/Min.hs
+++ b/src/Data/PQueue/Prio/Min.hs
@@ -101,9 +101,12 @@ module Data.PQueue.Prio.Min (
   toList,
   -- * Unordered operations
   foldrU,
+  foldMapWithKeyU,
   foldrWithKeyU,
   foldlU,
+  foldlU',
   foldlWithKeyU,
+  foldlWithKeyU',
   traverseU,
   traverseWithKeyU,
   keysU,
@@ -313,9 +316,16 @@ elemsU = List.map snd . toListU
 assocsU :: MinPQueue k a -> [(k, a)]
 assocsU = toListU
 
--- | /O(n)/. An unordered left fold over the elements of the queue, in no particular order.
+-- | /O(n)/. An unordered left fold over the elements of the queue, in no
+-- particular order.  This is rarely what you want; 'foldrU' and 'foldlU'' are
+-- more likely to perform well.
 foldlU :: (b -> a -> b) -> b -> MinPQueue k a -> b
 foldlU f = foldlWithKeyU (const . f)
+
+-- | /O(n)/. An unordered strict left fold over the elements of the queue, in no
+-- particular order.
+foldlU' :: (b -> a -> b) -> b -> MinPQueue k a -> b
+foldlU' f = foldlWithKeyU' (const . f)
 
 -- | /O(n)/. An unordered traversal over a priority queue, in no particular order.
 -- While there is no guarantee in which order the elements are traversed, the resulting


### PR DESCRIPTION
* As discussed in #55, we were recursively constructing `Foldable`
  dictionaries in unordered folds (for the basic queues, though not the
  `Prio` ones). Stop doing that.

* Add strict left unordered folds and monoidal unordered folds.