### PR TITLE
Use `tasty-bench` instead of `gauge`

### DIFF
--- a/.github/workflows/haskell.yaml
+++ b/.github/workflows/haskell.yaml
@@ -19,3 +19,5 @@ jobs:
         run: cabal build
       - name: Test
         run: cabal test --test-show-details=direct
+      - name: Build benchmarks
+        run: cabal build --enable-benchmarks

--- a/benchmarks/BenchMinPQueue.hs
+++ b/benchmarks/BenchMinPQueue.hs
@@ -1,5 +1,5 @@
 import System.Random
-import Gauge
+import Test.Tasty.Bench
 
 import qualified KWay.PrioMergeAlg as KWay
 import qualified PHeapSort as HS
@@ -15,7 +15,7 @@ hSort n = bench
   (nf (HS.heapSortRandoms n) $ mkStdGen (-7750349139967535027))
 
 main :: IO ()
-main = defaultMainWith defaultConfig{timeLimit = Just 15}
+main = defaultMain
   [ bgroup "heapSort"
       [ hSort (10^3)
       , hSort (10^4)

--- a/benchmarks/BenchMinQueue.hs
+++ b/benchmarks/BenchMinQueue.hs
@@ -1,5 +1,5 @@
 import System.Random
-import Gauge
+import Test.Tasty.Bench
 
 import qualified KWay.MergeAlg as KWay
 import qualified HeapSort as HS
@@ -14,9 +14,9 @@ hSort n = bench
   ("Heap sort with " ++ show n ++ " elements")
   (nf (HS.heapSortRandoms n) $ mkStdGen (-7750349139967535027))
 
-main = defaultMainWith defaultConfig{timeLimit = Just 15}
-  [
-    bgroup "heapSort"
+main :: IO ()
+main = defaultMain
+  [ bgroup "heapSort"
       [ hSort (10^3)
       , hSort (10^4)
       , hSort (10^5)

--- a/pqueue.cabal
+++ b/pqueue.cabal
@@ -78,34 +78,34 @@ test-suite test
 
 benchmark minqueue-benchmarks
   default-language: Haskell2010
-  type:           exitcode-stdio-1.0
-  hs-source-dirs: benchmarks
-  main-is:        BenchMinQueue.hs
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:   benchmarks
+  main-is:          BenchMinQueue.hs
   other-modules:
-      KWay.MergeAlg
-      HeapSort
-      KWay.RandomIncreasing
-  ghc-options:    -O2
+    KWay.MergeAlg
+    HeapSort
+    KWay.RandomIncreasing
+  ghc-options:      -O2
   build-depends:
-      base              >= 4.8 && < 5
+      base          >= 4.8 && < 5
     , pqueue
-    , deepseq           >= 1.3 && < 1.5
-    , gauge             >= 0.2.3 && < 0.3
-    , random            >= 1.2 && < 1.3
+    , deepseq       >= 1.3 && < 1.5
+    , random        >= 1.2 && < 1.3
+    , tasty-bench   >= 0.3 && < 0.4
 
 benchmark minpqueue-benchmarks
   default-language: Haskell2010
-  type:           exitcode-stdio-1.0
-  hs-source-dirs: benchmarks
-  main-is:        BenchMinPQueue.hs
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:   benchmarks
+  main-is:          BenchMinPQueue.hs
   other-modules:
-      KWay.PrioMergeAlg
-      PHeapSort
-      KWay.RandomIncreasing
-  ghc-options:    -O2
+    KWay.PrioMergeAlg
+    PHeapSort
+    KWay.RandomIncreasing
+  ghc-options:      -O2
   build-depends:
-      base              >= 4.8 && < 5
+      base          >= 4.8 && < 5
     , pqueue
-    , deepseq           >= 1.3 && < 1.5
-    , gauge             >= 0.2.3 && < 0.3
-    , random            >= 1.2 && < 1.3
+    , deepseq       >= 1.3 && < 1.5
+    , random        >= 1.2 && < 1.3
+    , tasty-bench   >= 0.3 && < 0.4


### PR DESCRIPTION
Reasons for using `tasty-bench`:
* actively maintained
* works on GHC 9.2
* [much more lightweight than `gauge`](https://github.com/Bodigrim/tasty-bench#how-lightweight-is-it) (less dependencies, less code, faster to compile)
* tests run a lot faster
* builtin support for [baseline comparisons](https://github.com/Bodigrim/tasty-bench#comparison-against-baseline)

Also see the [description](https://github.com/Bodigrim/tasty-bench#readme).