### PR TITLE
Expose `Data.PQueue.Prio.Max.foldlU'`

### DIFF
--- a/src/Data/PQueue/Prio/Max.hs
+++ b/src/Data/PQueue/Prio/Max.hs
@@ -105,6 +105,7 @@ module Data.PQueue.Prio.Max (
   foldrWithKeyU,
   foldMapWithKeyU,
   foldlU,
+  foldlU',
   foldlWithKeyU,
   foldlWithKeyU',
   traverseU,


### PR DESCRIPTION
This was added in #59, but only to `Data.PQueue.Prio.Max.Internals`, without being exposed by `Data.PQueue.Prio.Max`. @treeowl I assume this was an oversight?