### PR TITLE
Pattern synonyms and Data instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
     ([#92](http://github.com/lspitzner/pqueue/pull/92))
 
   * Make the `Data` instances respect the queue invariants. Make the
-    `Constructor`s match the pattern synonyms. Make the `Data` instance for
+    `Constr`s match the pattern synonyms. Make the `Data` instance for
     `MinPQueue` work "incrementally", like the one for `MinQueue`.
     ([#92](http://github.com/lspitzner/pqueue/pull/92))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Revision history for pqueue
 
+## 1.5.0
+
+  * Add pattern synonyms to work with `MinQueue` and `MinPQueue`.
+    ([#92](http://github.com/lspitzner/pqueue/pull/92))
+
+  * Make the `Data` instances respect the queue invariants. Make the
+    `Constructor`s match the pattern synonyms. Make the `Data` instance for
+    `MinPQueue` work "incrementally", like the one for `MinQueue`.
+    ([#92](http://github.com/lspitzner/pqueue/pull/92))
+
 ## 1.4.3.0 -- 2022-10-30
 
   * Add instances for [indexed-traversable](https://hackage.haskell.org/package/indexed-traversable).

--- a/src/Data/PQueue/Internals.hs
+++ b/src/Data/PQueue/Internals.hs
@@ -109,7 +109,7 @@ queueDataType = mkDataType "Data.PQueue.Min.MinQueue" [emptyConstr, consConstr]
 
 emptyConstr, consConstr :: Constr
 emptyConstr = mkConstr queueDataType "Empty" [] Prefix
-consConstr  = mkConstr queueDataType "(:<)" [] Infix
+consConstr  = mkConstr queueDataType ":<" [] Infix
 
 #endif
 

--- a/src/Data/PQueue/Internals.hs
+++ b/src/Data/PQueue/Internals.hs
@@ -1,15 +1,8 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE BangPatterns #-}
-#ifdef __GLASGOW_HASKELL__
-{-# LANGUAGE PatternSynonyms #-}
-{-# LANGUAGE ViewPatterns #-}
-#endif
 
 module Data.PQueue.Internals (
   MinQueue (..),
-#ifdef __GLASGOW_HASKELL__
-  pattern (:<),
-#endif
   BinomHeap,
   BinomForest(..),
   BinomTree(..),
@@ -88,24 +81,11 @@ fromBare xs = case BQ.minView xs of
   Nothing -> Empty
 
 #ifdef __GLASGOW_HASKELL__
-infixr 5 :<
-
--- | A bidirectional pattern synonym for working with the minimum view of a
--- 'MinPQueue'. Using @:<@ to construct a queue performs an insertion.
---
--- @since 1.5.0
-#  if __GLASGOW_HASKELL__ >= 800
-pattern (:<) :: Ord a => a -> MinQueue a -> MinQueue a
-#  else
-pattern (:<) :: () => Ord a => a -> MinQueue a -> MinQueue a
-#  endif
-pattern a :< q <- (minView -> Just (a, q))
-  where
-    a :< q = insert a q
 
 -- | Treats the priority queue as an empty queue or a minimal element and a
--- priority queue. The constructors, conceptually, are 'Empty' and '(:<)'. All
--- constructed queues maintain the queue invariants.
+-- priority queue. The constructors, conceptually, are 'Data.PQueue.Min.Empty'
+-- and '(Data.PQueue.Min.:<)'. All constructed queues maintain the queue
+-- invariants.
 instance (Ord a, Data a) => Data (MinQueue a) where
   gfoldl f z q = case minView q of
     Nothing      -> z Empty

--- a/src/Data/PQueue/Min.hs
+++ b/src/Data/PQueue/Min.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE CPP #-}
+#ifdef __GLASGOW_HASKELL__
+{-# LANGUAGE PatternSynonyms #-}
+#endif
 
 -----------------------------------------------------------------------------
 -- |
@@ -24,7 +27,13 @@
 -- these functions.
 -----------------------------------------------------------------------------
 module Data.PQueue.Min (
+#if __GLASGOW_HASKELL__ >= 802
+  MinQueue (Data.PQueue.Min.Empty, (Data.PQueue.Internals.:<)),
+#elif defined (__GLASGOW_HASKELL__)
   MinQueue,
+  pattern Empty,
+  pattern (:<),
+#endif
   -- * Basic operations
   empty,
   null,
@@ -92,7 +101,9 @@ import Data.Semigroup (Semigroup((<>)))
 
 import qualified Data.List as List
 
-import Data.PQueue.Internals
+import Data.PQueue.Internals hiding (MinQueue (..))
+import Data.PQueue.Internals (MinQueue (MinQueue))
+import qualified Data.PQueue.Internals as Internals
 import qualified BinomialQueue.Internals as BQ
 import qualified Data.PQueue.Prio.Internals as Prio
 
@@ -101,6 +112,14 @@ import GHC.Exts (build)
 #else
 build :: ((a -> [a] -> [a]) -> [a] -> [a]) -> [a]
 build f = f (:) []
+#endif
+
+#ifdef __GLASGOW_HASKELL__
+pattern Empty :: MinQueue a
+pattern Empty = Internals.Empty
+{-# INLINE Empty #-}
+
+{-# COMPLETE Empty, (:<) #-}
 #endif
 
 -- | \(O(1)\). Returns the minimum element. Throws an error on an empty queue.
@@ -220,7 +239,7 @@ elemsU = toListU
 
 -- | Constructs a priority queue out of the keys of the specified 'Prio.MinPQueue'.
 keysQueue :: Prio.MinPQueue k a -> MinQueue k
-keysQueue Prio.Empty = Empty
+keysQueue Prio.Empty = Internals.Empty
 keysQueue (Prio.MinPQ n k _ ts) = MinQueue n k (BQ.MinQueue (keysF (const Zero) ts))
 
 keysF :: (pRk k a -> rk k) -> Prio.BinomForest pRk k a -> BinomForest rk k

--- a/src/Data/PQueue/Min.hs
+++ b/src/Data/PQueue/Min.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP #-}
 #ifdef __GLASGOW_HASKELL__
 {-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ViewPatterns #-}
 #endif
 
 -----------------------------------------------------------------------------
@@ -28,10 +29,10 @@
 -----------------------------------------------------------------------------
 module Data.PQueue.Min (
 #if __GLASGOW_HASKELL__ >= 802
-  MinQueue (Data.PQueue.Min.Empty, (Data.PQueue.Internals.:<)),
+  MinQueue (Data.PQueue.Min.Empty, (:<)),
 #elif defined (__GLASGOW_HASKELL__)
   MinQueue,
-  pattern Empty,
+  pattern Data.PQueue.Min.Empty,
   pattern (:<),
 #endif
   -- * Basic operations
@@ -117,7 +118,27 @@ build f = f (:) []
 #ifdef __GLASGOW_HASKELL__
 pattern Empty :: MinQueue a
 pattern Empty = Internals.Empty
-{-# INLINE Empty #-}
+# if __GLASGOW_HASKELL__ >= 902
+{-# INLINE CONLIKE Empty #-}
+# endif
+
+infixr 5 :<
+
+-- | A bidirectional pattern synonym for working with the minimum view of a
+-- 'MinPQueue'. Using @:<@ to construct a queue performs an insertion.
+--
+-- @since 1.5.0
+# if __GLASGOW_HASKELL__ >= 800
+pattern (:<) :: Ord a => a -> MinQueue a -> MinQueue a
+# else
+pattern (:<) :: () => Ord a => a -> MinQueue a -> MinQueue a
+# endif
+pattern a :< q <- (minView -> Just (a, q))
+  where
+    a :< q = insert a q
+# if __GLASGOW_HASKELL__ >= 902
+{-# INLINE (:<) #-}
+# endif
 
 {-# COMPLETE Empty, (:<) #-}
 #endif

--- a/src/Data/PQueue/Min.hs
+++ b/src/Data/PQueue/Min.hs
@@ -116,6 +116,9 @@ build f = f (:) []
 #endif
 
 #ifdef __GLASGOW_HASKELL__
+-- | A bidirectional pattern synonym for an empty priority queue.
+--
+-- @since 1.5.0
 pattern Empty :: MinQueue a
 pattern Empty = Internals.Empty
 # if __GLASGOW_HASKELL__ >= 902
@@ -125,7 +128,9 @@ pattern Empty = Internals.Empty
 infixr 5 :<
 
 -- | A bidirectional pattern synonym for working with the minimum view of a
--- 'MinPQueue'. Using @:<@ to construct a queue performs an insertion.
+-- 'MinPQueue'.  Using @:<@ to construct a queue performs an insertion in
+-- \(O(1)\) amortized time. When matching on @a :< q@, forcing @q@ takes
+-- \(O(\log n)\) time.
 --
 -- @since 1.5.0
 # if __GLASGOW_HASKELL__ >= 800

--- a/src/Data/PQueue/Prio/Internals.hs
+++ b/src/Data/PQueue/Prio/Internals.hs
@@ -97,20 +97,20 @@ instance (Ord k, Data k, Data a) => Data (MinPQueue k a) where
     2 -> k (k (z (\(key, val) -> insert key val)))
     _ -> error "gunfold: invalid constructor for MinPQueue"
 
-  dataCast1 x = gcast1 x
-
   toConstr q
     | null q = emptyConstr
     | otherwise = consConstr
 
   dataTypeOf _ = queueDataType
+  dataCast1 f  = gcast1 f
+  dataCast2 f  = gcast2 f
 
 queueDataType :: DataType
 queueDataType = mkDataType "Data.PQueue.Prio.Min.MinPQueue" [emptyConstr, consConstr]
 
 emptyConstr, consConstr :: Constr
 emptyConstr = mkConstr queueDataType "Empty" [] Prefix
-consConstr  = mkConstr queueDataType "(:<)" [] Infix
+consConstr  = mkConstr queueDataType ":<" [] Infix
 #endif
 
 #if MIN_VERSION_base(4,9,0)

--- a/src/Data/PQueue/Prio/Internals.hs
+++ b/src/Data/PQueue/Prio/Internals.hs
@@ -2,14 +2,9 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-#ifdef __GLASGOW_HASKELL__
-{-# LANGUAGE PatternSynonyms #-}
-{-# LANGUAGE ViewPatterns #-}
-#endif
 
 module Data.PQueue.Prio.Internals (
   MinPQueue(..),
-  pattern (:<),
   BinomForest(..),
   BinomHeap,
   BinomTree(..),
@@ -86,22 +81,9 @@ build f = f (:) []
 
 #if __GLASGOW_HASKELL__
 
-infixr 5 :<
-
--- | A bidirectional pattern synonym for working with the minimum view of a
--- 'MinPQueue'. Using @:<@ to construct a queue performs an insertion.
-#  if __GLASGOW_HASKELL__ >= 800
-pattern (:<) :: Ord k => (k, a) -> MinPQueue k a -> MinPQueue k a
-#  else
-pattern (:<) :: () => Ord k => (k, a) -> MinPQueue k a -> MinPQueue k a
-#  endif
-pattern ka :< q <- (minViewWithKey -> Just (ka, q))
-  where
-    (k, a) :< q = insert k a q
-
 -- | Treats the priority queue as an empty queue or a minimal
 -- key-value pair and a priority queue. The constructors, conceptually,
--- are 'Empty' and '(:<)'.
+-- are 'Data.PQueue.Prio.Min.Empty' and '(Data.PQueue.Prio.Min.:<)'.
 --
 -- 'gfoldl' is nondeterministic; any minimal pair may be chosen as
 -- the first. All constructed queues maintain the queue invariants.

--- a/src/Data/PQueue/Prio/Internals.hs
+++ b/src/Data/PQueue/Prio/Internals.hs
@@ -2,9 +2,14 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+#ifdef __GLASGOW_HASKELL__
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ViewPatterns #-}
+#endif
 
 module Data.PQueue.Prio.Internals (
   MinPQueue(..),
+  pattern (:<),
   BinomForest(..),
   BinomHeap,
   BinomTree(..),
@@ -80,22 +85,50 @@ build f = f (:) []
 #endif
 
 #if __GLASGOW_HASKELL__
-instance (Data k, Data a, Ord k) => Data (MinPQueue k a) where
-  gfoldl f z m = z fromList `f` foldrWithKey (curry (:)) [] m
-  toConstr _   = fromListConstr
-  gunfold k z c  = case constrIndex c of
-    1 -> k (z fromList)
-    _ -> error "gunfold"
+
+infixr 5 :<
+
+-- | A bidirectional pattern synonym for working with the minimum view of a
+-- 'MinPQueue'. Using @:<@ to construct a queue performs an insertion.
+#  if __GLASGOW_HASKELL__ >= 800
+pattern (:<) :: Ord k => (k, a) -> MinPQueue k a -> MinPQueue k a
+#  else
+pattern (:<) :: () => Ord k => (k, a) -> MinPQueue k a -> MinPQueue k a
+#  endif
+pattern ka :< q <- (minViewWithKey -> Just (ka, q))
+  where
+    (k, a) :< q = insert k a q
+
+-- | Treats the priority queue as an empty queue or a minimal
+-- key-value pair and a priority queue. The constructors, conceptually,
+-- are 'Empty' and '(:<)'.
+--
+-- 'gfoldl' is nondeterministic; any minimal pair may be chosen as
+-- the first. All constructed queues maintain the queue invariants.
+instance (Ord k, Data k, Data a) => Data (MinPQueue k a) where
+  gfoldl f z q = case minViewWithKey q of
+    Nothing      -> z Empty
+    Just (x, q') -> z (\(k, a) -> insert k a) `f` x `f` q'
+
+  gunfold k z c = case constrIndex c of
+    1 -> z Empty
+    2 -> k (k (z (\(key, val) -> insert key val)))
+    _ -> error "gunfold: invalid constructor for MinPQueue"
+
+  dataCast1 x = gcast1 x
+
+  toConstr q
+    | null q = emptyConstr
+    | otherwise = consConstr
+
   dataTypeOf _ = queueDataType
-  dataCast1 f  = gcast1 f
-  dataCast2 f  = gcast2 f
 
 queueDataType :: DataType
-queueDataType = mkDataType "Data.PQueue.Prio.Min.MinPQueue" [fromListConstr]
+queueDataType = mkDataType "Data.PQueue.Prio.Min.MinPQueue" [emptyConstr, consConstr]
 
-fromListConstr :: Constr
-fromListConstr = mkConstr queueDataType "fromList" [] Prefix
-
+emptyConstr, consConstr :: Constr
+emptyConstr = mkConstr queueDataType "Empty" [] Prefix
+consConstr  = mkConstr queueDataType "(:<)" [] Infix
 #endif
 
 #if MIN_VERSION_base(4,9,0)
@@ -147,8 +180,8 @@ second' f (a, b) = (a, f b)
 
 infixr 8 .:
 
--- | A priority queue where values of type @a@ are annotated with keys of type @k@.
--- The queue supports extracting the element with minimum key.
+-- | A priority queue where keys of type @k@ are annotated with values of type
+-- @a@.  The queue supports extracting the key-value pair with minimum key.
 data MinPQueue k a = Empty | MinPQ {-# UNPACK #-} !Int !k a !(BinomHeap k a)
 
 data BinomForest rk k a =

--- a/src/Data/PQueue/Prio/Min.hs
+++ b/src/Data/PQueue/Prio/Min.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE PatternSynonyms #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -29,7 +30,13 @@
 -- these functions.
 -----------------------------------------------------------------------------
 module Data.PQueue.Prio.Min (
+#if __GLASGOW_HASKELL__ >= 802
+  MinPQueue (Data.PQueue.Prio.Min.Empty, (:<)),
+#elif defined (__GLASGOW_HASKELL__)
   MinPQueue,
+  pattern Empty,
+  pattern (:<),
+#endif
   -- * Construction
   empty,
   singleton,
@@ -128,7 +135,9 @@ import Data.Maybe (fromMaybe)
 import Data.Semigroup (Semigroup((<>)))
 #endif
 
-import Data.PQueue.Prio.Internals
+import Data.PQueue.Prio.Internals hiding (MinPQueue (..))
+import Data.PQueue.Prio.Internals (MinPQueue)
+import qualified Data.PQueue.Prio.Internals as Internals
 
 import Prelude hiding (map, filter, break, span, takeWhile, dropWhile, splitAt, take, drop, (!!), null)
 
@@ -137,6 +146,15 @@ import GHC.Exts (build)
 #else
 build :: ((a -> [a] -> [a]) -> [a] -> [a]) -> [a]
 build f = f (:) []
+#endif
+
+#ifdef __GLASGOW_HASKELL__
+-- | A bidirectional pattern synonym for an empty priority queue.
+pattern Empty :: MinPQueue k a
+pattern Empty = Internals.Empty
+{-# INLINE Empty #-}
+
+{-# COMPLETE Empty, (:<) #-}
 #endif
 
 (.:) :: (c -> d) -> (a -> b -> c) -> a -> b -> d

--- a/src/Data/PQueue/Prio/Min.hs
+++ b/src/Data/PQueue/Prio/Min.hs
@@ -151,6 +151,8 @@ build f = f (:) []
 
 #ifdef __GLASGOW_HASKELL__
 -- | A bidirectional pattern synonym for an empty priority queue.
+--
+-- @since 1.5.0
 pattern Empty :: MinPQueue k a
 pattern Empty = Internals.Empty
 # if __GLASGOW_HASKELL__ >= 902
@@ -160,7 +162,11 @@ pattern Empty = Internals.Empty
 infixr 5 :<
 
 -- | A bidirectional pattern synonym for working with the minimum view of a
--- 'MinPQueue'. Using @:<@ to construct a queue performs an insertion.
+-- 'MinPQueue'. Using @:<@ to construct a queue performs an insertion in
+-- \(O(1)\) amortized time. When matching on @(k, a) :< q@, forcing @q@ takes
+-- \(O(\log n)\) time.
+--
+-- @since 1.5.0
 # if __GLASGOW_HASKELL__ >= 800
 pattern (:<) :: Ord k => (k, a) -> MinPQueue k a -> MinPQueue k a
 # else

--- a/src/Data/PQueue/Prio/Min.hs
+++ b/src/Data/PQueue/Prio/Min.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ViewPatterns #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -34,7 +35,7 @@ module Data.PQueue.Prio.Min (
   MinPQueue (Data.PQueue.Prio.Min.Empty, (:<)),
 #elif defined (__GLASGOW_HASKELL__)
   MinPQueue,
-  pattern Empty,
+  pattern Data.PQueue.Prio.Min.Empty,
   pattern (:<),
 #endif
   -- * Construction
@@ -152,7 +153,25 @@ build f = f (:) []
 -- | A bidirectional pattern synonym for an empty priority queue.
 pattern Empty :: MinPQueue k a
 pattern Empty = Internals.Empty
-{-# INLINE Empty #-}
+# if __GLASGOW_HASKELL__ >= 902
+{-# INLINE CONLIKE Empty #-}
+# endif
+
+infixr 5 :<
+
+-- | A bidirectional pattern synonym for working with the minimum view of a
+-- 'MinPQueue'. Using @:<@ to construct a queue performs an insertion.
+# if __GLASGOW_HASKELL__ >= 800
+pattern (:<) :: Ord k => (k, a) -> MinPQueue k a -> MinPQueue k a
+# else
+pattern (:<) :: () => Ord k => (k, a) -> MinPQueue k a -> MinPQueue k a
+# endif
+pattern ka :< q <- (minViewWithKey -> Just (ka, q))
+  where
+    (k, a) :< q = insert k a q
+# if __GLASGOW_HASKELL__ >= 902
+{-# INLINE (:<) #-}
+# endif
 
 {-# COMPLETE Empty, (:<) #-}
 #endif


### PR DESCRIPTION
* Add some pattern synonyms.
* Improve the `Data` instances to
  - Make the `MinPQueue` version incremental, like the `MinQueue` one.
  - Make all the instances respect the queue invariants.
* Use the pattern synonyms to explain the `Data` instances.

Fixes #50.