### PR TITLE
Deprecate seqSpine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.5.0
 
+  * Deprecate `seqSpine`. Changes in version 1.4.2.0 made it useless.
+
   * Add pattern synonyms to work with `MinQueue` and `MinPQueue`.
     ([#92](http://github.com/lspitzner/pqueue/pull/92))
 

--- a/src/Data/PQueue/Internals.hs
+++ b/src/Data/PQueue/Internals.hs
@@ -343,9 +343,10 @@ toListUApp (MinQueue _ x ts) app = x : BQ.foldrU (:) app ts
 --
 -- Note: The spine of a 'MinQueue' is stored somewhat lazily. Most operations
 -- take great care to prevent chains of thunks from accumulating along the
--- spine to the detriment of performance. However, @mapU@ can leave expensive
--- thunks in the structure and repeated applications of that function can
--- create thunk chains.
+-- spine to the detriment of performance. The only one that doesn't,
+-- 'mapU', does not benefit from forcing the spine anyway. Forcing the spine
+-- of the result just forces the creation of thunks for all the elements.
+{-# DEPRECATED seqSpine "This function is no longer useful." #-}
 seqSpine :: MinQueue a -> b -> b
 seqSpine Empty z = z
 seqSpine (MinQueue _ _ ts) z = BQ.seqSpine ts z

--- a/src/Data/PQueue/Max.hs
+++ b/src/Data/PQueue/Max.hs
@@ -371,8 +371,9 @@ keysQueue (Prio.MaxPQ q) = MaxQ (Min.keysQueue q)
 --
 -- Note: The spine of a 'MaxQueue' is stored somewhat lazily. Most operations
 -- take great care to prevent chains of thunks from accumulating along the
--- spine to the detriment of performance. However, 'mapU' can leave expensive
--- thunks in the structure and repeated applications of that function can
--- create thunk chains.
+-- spine to the detriment of performance. The only one that doesn't,
+-- 'mapU', does not benefit from forcing the spine anyway. Forcing the spine
+-- of the result just forces the creation of thunks for all the elements.
+{-# DEPRECATED seqSpine "This function is no longer useful." #-}
 seqSpine :: MaxQueue a -> b -> b
 seqSpine (MaxQ q) = Min.seqSpine q

--- a/src/Data/PQueue/Prio/Internals.hs
+++ b/src/Data/PQueue/Prio/Internals.hs
@@ -758,9 +758,11 @@ mapKeysMonoF f fCh ts0 = case ts0 of
 --
 -- Note: The spine of a 'MinPQueue' is stored somewhat lazily. Most operations
 -- take great care to prevent chains of thunks from accumulating along the
--- spine to the detriment of performance. However, 'mapKeysMonotonic' can leave
--- expensive thunks in the structure and repeated applications of that function
--- can create thunk chains.
+-- spine to the detriment of performance. The only ones that don't,
+-- 'mapKeysMonotonic', 'mapWithKey', 'traverseWithKey', etc., do not benefit
+-- from forcing the spine anyway. Forcing the spine just forces the creation
+-- of thunks for all the elements.
+{-# DEPRECATED seqSpine "This function is no longer useful." #-}
 seqSpine :: MinPQueue k a -> b -> b
 seqSpine Empty z0 = z0
 seqSpine (MinPQ _ _ _ ts0) z0 = ts0 `seqSpineF` z0 where

--- a/src/Data/PQueue/Prio/Max/Internals.hs
+++ b/src/Data/PQueue/Prio/Max/Internals.hs
@@ -577,10 +577,12 @@ toListU (MaxPQ q) = fmap (first' unDown) (Q.toListU q)
 
 -- | \(O(\log n)\). @seqSpine q r@ forces the spine of @q@ and returns @r@.
 --
--- Note: The spine of a 'MaxPQueue' is stored somewhat lazily. Most operations
+-- Note: The spine of a 'MinPQueue' is stored somewhat lazily. Most operations
 -- take great care to prevent chains of thunks from accumulating along the
--- spine to the detriment of performance. However, 'mapKeysMonotonic' can leave
--- expensive thunks in the structure and repeated applications of that function
--- can create thunk chains.
+-- spine to the detriment of performance. The only ones that don't,
+-- 'mapKeysMonotonic', 'mapWithKey', 'traverseWithKey', etc., do not benefit
+-- from forcing the spine anyway. Forcing the spine just forces the creation
+-- of thunks for all the elements.
+{-# DEPRECATED seqSpine "This function is no longer useful." #-}
 seqSpine :: MaxPQueue k a -> b -> b
 seqSpine (MaxPQ q) = Q.seqSpine q


### PR DESCRIPTION
The `seqSpine` function was useful back in the day when all sorts of operations were written in a way that allowed thunks to accumulate along the spine. Now, we carefully force as much of the spine as the amortized bounds allow, which eliminates this problem in general. The only operations that still accumulate thunks along the spine are monotonic maps, and forcing the spines of those just leads to the creation of more thunks at the leaves—it's not really useful.