### PR TITLE
Deprecate insertBehind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 1.5.0
 
+  * Deprecate `insertBehind`. This function does not play nicely with merges,
+    we lack tests to verify it works properly without merges, it imposes a
+    substantial maintenance burden on the rest of the package, and it is quite
+    slow. ([#35](https://github.com/lspitzner/pqueue/issues/35))
+
   * Add pattern synonyms to work with `MinQueue` and `MinPQueue`.
     ([#92](http://github.com/lspitzner/pqueue/pull/92))
 

--- a/src/Data/PQueue/Prio/Internals.hs
+++ b/src/Data/PQueue/Prio/Internals.hs
@@ -272,6 +272,7 @@ insert k a (MinPQ n k' a' ts)
 -- Insert an element with the specified key into the priority queue,
 -- putting it behind elements whose key compares equal to the
 -- inserted one.
+{-# DEPRECATED insertBehind "This function is not reliable." #-}
 insertBehind :: Ord k => k -> a -> MinPQueue k a -> MinPQueue k a
 insertBehind k v q =
   let (smaller, larger) = spanKey (<= k) q

--- a/src/Data/PQueue/Prio/Max/Internals.hs
+++ b/src/Data/PQueue/Prio/Max/Internals.hs
@@ -226,6 +226,7 @@ insert k a (MaxPQ q) = MaxPQ (Q.insert (Down k) a q)
 -- Insert an element with the specified key into the priority queue,
 -- putting it behind elements whose key compares equal to the
 -- inserted one.
+{-# DEPRECATED insertBehind "This function is not reliable." #-}
 insertBehind :: Ord k => k -> a -> MaxPQueue k a -> MaxPQueue k a
 insertBehind k a (MaxPQ q) = MaxPQ (Q.insertBehind (Down k) a q)
 


### PR DESCRIPTION
`insertBehind` does not interact in any particularly sensible way with merges. I don't have a lot of faith that it works in other cases at all—it's far too fragile. It's also too slow to be really useful.

First stage in #35