### PR TITLE
Remove `foldWhileFB`

### DIFF
--- a/src/BinomialQueue/Max.hs
+++ b/src/BinomialQueue/Max.hs
@@ -136,7 +136,7 @@ maxView (MaxQueue q) = case MinQ.minView q of
 (!!) :: Ord a => MaxQueue a -> Int -> a
 q !! n  | n >= size q
     = error "BinomialQueue.Max.!!: index too large"
-q !! n = (List.!!) (toDescList q) n
+q !! n = toDescList q List.!! n
 
 {-# INLINE takeWhile #-}
 -- | 'takeWhile', applied to a predicate @p@ and a queue @queue@, returns the

--- a/src/BinomialQueue/Min.hs
+++ b/src/BinomialQueue/Min.hs
@@ -125,22 +125,13 @@ deleteFindMin = fromMaybe (error "Error: deleteFindMin called on empty queue") .
 (!!) :: Ord a => MinQueue a -> Int -> a
 q !! n  | n >= size q
     = error "Data.PQueue.Min.!!: index too large"
-q !! n = (List.!!) (toAscList q) n
+q !! n = toAscList q List.!! n
 
 {-# INLINE takeWhile #-}
 -- | 'takeWhile', applied to a predicate @p@ and a queue @queue@, returns the
 -- longest prefix (possibly empty) of @queue@ of elements that satisfy @p@.
 takeWhile :: Ord a => (a -> Bool) -> MinQueue a -> [a]
-takeWhile p = foldWhileFB p . toAscList
-
-{-# INLINE foldWhileFB #-}
--- | Equivalent to Data.List.takeWhile, but is a better producer.
-foldWhileFB :: (a -> Bool) -> [a] -> [a]
-foldWhileFB p xs0 = build (\c nil -> let
-  consWhile x xs
-    | p x    = x `c` xs
-    | otherwise  = nil
-  in foldr consWhile nil xs0)
+takeWhile p = List.takeWhile p . toAscList
 
 -- | 'dropWhile' @p queue@ returns the queue remaining after 'takeWhile' @p queue@.
 dropWhile :: Ord a => (a -> Bool) -> MinQueue a -> MinQueue a

--- a/src/Data/PQueue/Min.hs
+++ b/src/Data/PQueue/Min.hs
@@ -167,22 +167,13 @@ deleteFindMin = fromMaybe (error "Error: deleteFindMin called on empty queue") .
 (!!) :: Ord a => MinQueue a -> Int -> a
 q !! n  | n >= size q
     = error "Data.PQueue.Min.!!: index too large"
-q !! n = (List.!!) (toAscList q) n
+q !! n = toAscList q List.!! n
 
 {-# INLINE takeWhile #-}
 -- | 'takeWhile', applied to a predicate @p@ and a queue @queue@, returns the
 -- longest prefix (possibly empty) of @queue@ of elements that satisfy @p@.
 takeWhile :: Ord a => (a -> Bool) -> MinQueue a -> [a]
-takeWhile p = foldWhileFB p . toAscList
-
-{-# INLINE foldWhileFB #-}
--- | Equivalent to Data.List.takeWhile, but is a better producer.
-foldWhileFB :: (a -> Bool) -> [a] -> [a]
-foldWhileFB p xs0 = build (\c nil -> let
-  consWhile x xs
-    | p x    = x `c` xs
-    | otherwise  = nil
-  in foldr consWhile nil xs0)
+takeWhile p = List.takeWhile p . toAscList
 
 -- | 'dropWhile' @p queue@ returns the queue remaining after 'takeWhile' @p queue@.
 dropWhile :: Ord a => (a -> Bool) -> MinQueue a -> MinQueue a

--- a/src/Data/PQueue/Prio/Min.hs
+++ b/src/Data/PQueue/Prio/Min.hs
@@ -316,8 +316,7 @@ takeWhile = takeWhileWithKey . const
 -- | Takes the longest possible prefix of elements satisfying the predicate.
 -- (@'takeWhile' p q == 'List.takeWhile' (uncurry p) ('toAscList' q)@)
 takeWhileWithKey :: Ord k => (k -> a -> Bool) -> MinPQueue k a -> [(k, a)]
-takeWhileWithKey p0 = takeWhileFB (uncurry' p0) . toAscList where
-  takeWhileFB p xs = build (\c n -> foldr (\x z -> if p x then x `c` z else n) n xs)
+takeWhileWithKey p0 = List.takeWhile (uncurry' p0) . toAscList
 
 -- | Removes the longest possible prefix of elements satisfying the predicate.
 dropWhile :: Ord k => (a -> Bool) -> MinPQueue k a -> MinPQueue k a


### PR DESCRIPTION
Closes #98.

`takeWhile` has a rewrite rule that does the same (https://hackage.haskell.org/package/base-4.18.0.0/docs/src/GHC.List.html#takeWhile) since base-4.9. I also did a small micro-benchmark that seems to confirm that there is no performance regression.