### PR TITLE
Strictify maps

### DIFF
--- a/src/BinomialQueue/Internals.hs
+++ b/src/BinomialQueue/Internals.hs
@@ -536,8 +536,8 @@ instance Functor rk => Functor (BinomTree rk) where
 
 instance Functor rk => Functor (BinomForest rk) where
   fmap _ Nil = Nil
-  fmap f (Skip ts) = Skip (fmap f ts)
-  fmap f (Cons t ts) = Cons (fmap f t) (fmap f ts)
+  fmap f (Skip ts) = Skip $! fmap f ts
+  fmap f (Cons t ts) = Cons (fmap f t) $! fmap f ts
 
 instance Foldr Zero where
   foldr_ _ z ~Zero = z

--- a/src/Data/PQueue/Internals.hs
+++ b/src/Data/PQueue/Internals.hs
@@ -341,11 +341,11 @@ toListUApp (MinQueue _ x ts) app = x : BQ.foldrU (:) app ts
 
 -- | \(O(\log n)\). @seqSpine q r@ forces the spine of @q@ and returns @r@.
 --
--- Note: The spine of a 'MinQueue' is stored somewhat lazily. Most operations
--- take great care to prevent chains of thunks from accumulating along the
--- spine to the detriment of performance. However, @mapU@ can leave expensive
--- thunks in the structure and repeated applications of that function can
--- create thunk chains.
+-- Note: The spine of a 'MinQueue' is stored somewhat lazily. In earlier
+-- versions of this package, some operations could produce chains of thunks
+-- along the spine, occasionally necessitating manual forcing. Now, all
+-- operations are careful to force enough to avoid this problem.
+{-# DEPRECATED seqSpine "This function is no longer necessary or useful." #-}
 seqSpine :: MinQueue a -> b -> b
 seqSpine Empty z = z
 seqSpine (MinQueue _ _ ts) z = BQ.seqSpine ts z

--- a/src/Data/PQueue/Max.hs
+++ b/src/Data/PQueue/Max.hs
@@ -369,10 +369,10 @@ keysQueue (Prio.MaxPQ q) = MaxQ (Min.keysQueue q)
 
 -- | \(O(\log n)\). @seqSpine q r@ forces the spine of @q@ and returns @r@.
 --
--- Note: The spine of a 'MaxQueue' is stored somewhat lazily. Most operations
--- take great care to prevent chains of thunks from accumulating along the
--- spine to the detriment of performance. However, 'mapU' can leave expensive
--- thunks in the structure and repeated applications of that function can
--- create thunk chains.
+-- Note: The spine of a 'MaxQueue' is stored somewhat lazily. In earlier
+-- versions of this package, some operations could produce chains of thunks
+-- along the spine, occasionally necessitating manual forcing. Now, all
+-- operations are careful to force enough to avoid this problem.
+{-# DEPRECATED seqSpine "This function is no longer necessary or useful." #-}
 seqSpine :: MaxQueue a -> b -> b
 seqSpine (MaxQ q) = Min.seqSpine q

--- a/src/Data/PQueue/Min.hs
+++ b/src/Data/PQueue/Min.hs
@@ -262,7 +262,7 @@ keysQueue (Prio.MinPQ n k _ ts) = MinQueue n k (BQ.MinQueue (keysF (const Zero) 
 keysF :: (pRk k a -> rk k) -> Prio.BinomForest pRk k a -> BinomForest rk k
 keysF f ts0 = case ts0 of
   Prio.Nil       -> Nil
-  Prio.Skip ts'  -> Skip (keysF f' ts')
+  Prio.Skip ts'  -> Skip $! keysF f' ts'
   Prio.Cons (Prio.BinomTree k _ ts) ts'
-    -> Cons (BinomTree k (f ts)) (keysF f' ts')
+    -> Cons (BinomTree k (f ts)) $! keysF f' ts'
   where  f' (Prio.Succ (Prio.BinomTree k _ ts) tss) = Succ (BinomTree k (f ts)) (f tss)

--- a/src/Data/PQueue/Prio/Internals.hs
+++ b/src/Data/PQueue/Prio/Internals.hs
@@ -757,11 +757,11 @@ mapKeysMonoF f fCh ts0 = case ts0 of
 
 -- | \(O(\log n)\). @seqSpine q r@ forces the spine of @q@ and returns @r@.
 --
--- Note: The spine of a 'MinPQueue' is stored somewhat lazily. Most operations
--- take great care to prevent chains of thunks from accumulating along the
--- spine to the detriment of performance. However, 'mapKeysMonotonic' can leave
--- expensive thunks in the structure and repeated applications of that function
--- can create thunk chains.
+-- Note: The spine of a 'MinPQueue' is stored somewhat lazily. In earlier
+-- versions of this package, some operations could produce chains of thunks
+-- along the spine, occasionally necessitating manual forcing. Now, all
+-- operations are careful to force enough to avoid this problem.
+{-# DEPRECATED seqSpine "This function is no longer necessary or useful." #-}
 seqSpine :: MinPQueue k a -> b -> b
 seqSpine Empty z0 = z0
 seqSpine (MinPQ _ _ _ ts0) z0 = ts0 `seqSpineF` z0 where

--- a/src/Data/PQueue/Prio/Max/Internals.hs
+++ b/src/Data/PQueue/Prio/Max/Internals.hs
@@ -578,10 +578,10 @@ toListU (MaxPQ q) = fmap (first' unDown) (Q.toListU q)
 
 -- | \(O(\log n)\). @seqSpine q r@ forces the spine of @q@ and returns @r@.
 --
--- Note: The spine of a 'MaxPQueue' is stored somewhat lazily. Most operations
--- take great care to prevent chains of thunks from accumulating along the
--- spine to the detriment of performance. However, 'mapKeysMonotonic' can leave
--- expensive thunks in the structure and repeated applications of that function
--- can create thunk chains.
+-- Note: The spine of a 'MaxPQueue' is stored somewhat lazily. In earlier
+-- versions of this package, some operations could produce chains of thunks
+-- along the spine, occasionally necessitating manual forcing. Now, all
+-- operations are careful to force enough to avoid this problem.
+{-# DEPRECATED seqSpine "This function is no longer necessary or useful." #-}
 seqSpine :: MaxPQueue k a -> b -> b
 seqSpine (MaxPQ q) = Q.seqSpine q


### PR DESCRIPTION
* Make mapping force spines.
* Deprecate `seqSpine`. It shouldn't be needed any more.

Closes #100