### PR TITLE
Restore shape invariant

### DIFF
--- a/pqueue.cabal
+++ b/pqueue.cabal
@@ -66,16 +66,38 @@ library
       -fno-warn-unused-imports
 
 test-suite test
-  hs-source-dirs: tests
+  hs-source-dirs: src, tests
   default-language: Haskell2010
   type: exitcode-stdio-1.0
   main-is: PQueueTests.hs
   build-depends:
   { base >= 4.8 && < 4.19
+  , containers
   , deepseq >= 1.3 && < 1.5
+  , indexed-traversable >= 0.1 && < 0.2
   , tasty
   , tasty-quickcheck
-  , pqueue
+  }
+  other-modules:
+    Data.PQueue.Prio.Min
+    Data.PQueue.Prio.Max
+    Data.PQueue.Min
+    Data.PQueue.Max
+    Data.PQueue.Prio.Internals
+    Data.PQueue.Internals
+    BinomialQueue.Internals
+    BinomialQueue.Min
+    BinomialQueue.Max
+    Data.PQueue.Internals.Down
+    Data.PQueue.Internals.Foldable
+    Data.PQueue.Prio.Max.Internals
+
+    Validity.BinomialQueue
+    Validity.PQueue.Min
+    Validity.PQueue.Prio.BinomialQueue
+    Validity.PQueue.Prio.Min
+  if impl(ghc) {
+    default-extensions: DeriveDataTypeable
   }
   ghc-options:
     -Wall

--- a/src/BinomialQueue/Internals.hs
+++ b/src/BinomialQueue/Internals.hs
@@ -356,7 +356,7 @@ extractBin = start
       No     -> No
       Yes ex -> Yes (incrExtract ex)
     start (Cons t@(BinomTree x ts) f) = Yes $ case go x f of
-      No -> Extract x ts (Skip f)
+      No -> Extract x ts (skip f)
       Yes ex -> incrExtract' t ex
 
     go :: Ord a => a -> BinomForest rk a -> MExtract rk a
@@ -369,8 +369,15 @@ extractBin = start
           No -> No
           Yes ex -> Yes (incrExtract' t ex)
       | otherwise = case go x f of
-          No -> Yes (Extract x ts (Skip f))
+          No -> Yes (Extract x ts (skip f))
           Yes ex -> Yes (incrExtract' t ex)
+
+-- | When the heap size is a power of two and we extract from it, we have
+-- to shrink the spine by one. This function takes care of that.
+skip :: BinomForest (Succ rk) a -> BinomForest rk a
+skip Nil = Nil
+skip f = Skip f
+{-# INLINE skip #-}
 
 mapMaybeQueue :: Ord b => (a -> Maybe b) -> (rk a -> MinQueue b) -> MinQueue b -> BinomForest rk a -> MinQueue b
 mapMaybeQueue f fCh q0 forest = q0 `seq` case forest of

--- a/src/Data/PQueue/Internals.hs
+++ b/src/Data/PQueue/Internals.hs
@@ -37,7 +37,7 @@ module Data.PQueue.Internals (
   foldlU',
 --   traverseU,
   seqSpine,
-  unions
+  unions,
   ) where
 
 import BinomialQueue.Internals

--- a/src/Data/PQueue/Prio/Internals.hs
+++ b/src/Data/PQueue/Prio/Internals.hs
@@ -590,7 +590,7 @@ extract = start
       No     -> No
       Yes ex -> Yes (incrExtract ex)
     start (Cons t@(BinomTree k v ts) f) = Yes $ case go k f of
-      No -> Extract k v ts (Skip f)
+      No -> Extract k v ts (skip f)
       Yes ex -> incrExtract' t ex
 
     go :: Ord k => k -> BinomForest rk k a -> MExtract rk k a
@@ -603,8 +603,13 @@ extract = start
           No -> No
           Yes ex -> Yes (incrExtract' t ex)
       | otherwise = case go k f of
-          No -> Yes (Extract k v ts (Skip f))
+          No -> Yes (Extract k v ts (skip f))
           Yes ex -> Yes (incrExtract' t ex)
+
+skip :: BinomForest (Succ rk) k a -> BinomForest rk k a
+skip Nil = Nil
+skip f = Skip f
+{-# INLINE skip #-}
 
 -- | Utility function for mapping over a forest.
 mapForest :: (k -> a -> b) -> (rk k a -> rk k b) -> BinomForest rk k a -> BinomForest rk k b

--- a/tests/Validity/BinomialQueue.hs
+++ b/tests/Validity/BinomialQueue.hs
@@ -1,0 +1,49 @@
+-- | Validity testing
+module Validity.BinomialQueue
+  ( validShape
+  , precedesProperly
+  ) where
+
+import BinomialQueue.Internals
+
+-- | Does the heap have a valid shape?
+validShape :: MinQueue a -> Bool
+validShape (MinQueue f) = validShapeF f
+  
+validShapeF :: BinomForest rk a -> Bool
+validShapeF (Cons _ f) = validShapeF f
+validShapeF (Skip Nil) = False
+validShapeF (Skip _f) = True
+validShapeF Nil = True
+  
+-- | Takes an element and a priority queue. Checks that the queue is in heap
+-- order and that the element is less than or equal to all elements of the
+-- queue.
+precedesProperly :: Ord a => a -> MinQueue a -> Bool
+precedesProperly a (MinQueue q) = precedesProperlyF a q
+  
+-- | Takes an element and a forest. Checks that the forest is in heap order
+-- and that the element is less than or equal to all elements of the forest.
+precedesProperlyF :: (Ord a, TreeValidity rk) => a -> BinomForest rk a -> Bool
+precedesProperlyF _ Nil = True
+precedesProperlyF the_min (Skip f) = precedesProperlyF the_min f
+precedesProperlyF the_min (Cons t ts) = precedesProperlyTree the_min t
+  && precedesProperlyF the_min ts
+  
+-- | Takes an element and a tree. Checks that the tree is in heap order
+-- and that the element is less than or equal to all elements of the tree.
+precedesProperlyTree :: (Ord a, TreeValidity rk) => a -> BinomTree rk a -> Bool
+precedesProperlyTree the_min (BinomTree a ts) = the_min <= a && precedesProperlyRk a ts
+  
+-- | A helper class for order validity checking
+class TreeValidity rk where
+  -- | Takes an element and a collection of trees. Checks that the collection
+  -- is in heap order and that the element is less than or equal to all
+  -- elements of the collection.
+  precedesProperlyRk :: Ord a => a -> rk a -> Bool
+instance TreeValidity Zero where
+  precedesProperlyRk _ ~Zero = True
+instance TreeValidity rk => TreeValidity (Succ rk) where
+  precedesProperlyRk the_min (Succ t q) =
+    precedesProperlyTree the_min t &&
+    precedesProperlyRk the_min q

--- a/tests/Validity/PQueue/Min.hs
+++ b/tests/Validity/PQueue/Min.hs
@@ -1,0 +1,21 @@
+module Validity.PQueue.Min
+  ( validShape
+  , validSize
+  , validOrder
+  ) where
+
+import Data.PQueue.Internals
+import qualified BinomialQueue.Internals as BQ
+import qualified Validity.BinomialQueue as VBQ
+
+validShape :: MinQueue a -> Bool
+validShape Empty = True
+validShape (MinQueue _ _ f) = VBQ.validShape f
+
+validSize :: MinQueue a -> Bool
+validSize Empty = True
+validSize (MinQueue sz _ f) = sz == BQ.size f + 1
+
+validOrder :: Ord a => MinQueue a -> Bool
+validOrder Empty = True
+validOrder (MinQueue _sz a f) = VBQ.precedesProperly a f

--- a/tests/Validity/PQueue/Prio/BinomialQueue.hs
+++ b/tests/Validity/PQueue/Prio/BinomialQueue.hs
@@ -1,0 +1,40 @@
+-- | Validity testing
+module Validity.PQueue.Prio.BinomialQueue
+  ( validShapeF
+  , precedesProperlyF
+  ) where
+
+import Data.PQueue.Prio.Internals
+
+-- | Does the heap have a valid shape?
+validShapeF :: BinomForest rk k a -> Bool
+validShapeF (Cons _ f) = validShapeF f
+validShapeF (Skip Nil) = False
+validShapeF (Skip _f) = True
+validShapeF Nil = True
+  
+-- | Takes an element and a forest. Checks that the forest is in heap order
+-- and that the element is less than or equal to all elements of the forest.
+precedesProperlyF :: (Ord k, TreeValidity rk) => k -> BinomForest rk k a -> Bool
+precedesProperlyF _ Nil = True
+precedesProperlyF the_min (Skip f) = precedesProperlyF the_min f
+precedesProperlyF the_min (Cons t ts) = precedesProperlyTree the_min t
+  && precedesProperlyF the_min ts
+  
+-- | Takes an element and a tree. Checks that the tree is in heap order
+-- and that the element is less than or equal to all elements of the tree.
+precedesProperlyTree :: (Ord k, TreeValidity rk) => k -> BinomTree rk k a -> Bool
+precedesProperlyTree the_min (BinomTree k a ts) = the_min <= k && precedesProperlyRk k ts
+  
+-- | A helper class for order validity checking
+class TreeValidity rk where
+  -- | Takes an element and a collection of trees. Checks that the collection
+  -- is in heap order and that the element is less than or equal to all
+  -- elements of the collection.
+  precedesProperlyRk :: Ord k => k -> rk k a -> Bool
+instance TreeValidity Zero where
+  precedesProperlyRk _ ~Zero = True
+instance TreeValidity rk => TreeValidity (Succ rk) where
+  precedesProperlyRk the_min (Succ t q) =
+    precedesProperlyTree the_min t &&
+    precedesProperlyRk the_min q

--- a/tests/Validity/PQueue/Prio/Min.hs
+++ b/tests/Validity/PQueue/Prio/Min.hs
@@ -1,0 +1,28 @@
+module Validity.PQueue.Prio.Min
+  ( validShape
+  , validSize
+  , validOrder
+  ) where
+
+import Data.PQueue.Prio.Internals as BQ
+import qualified Validity.PQueue.Prio.BinomialQueue as VBQ
+
+validShape :: MinPQueue k a -> Bool
+validShape Empty = True
+validShape (MinPQ _ _ _ f) = VBQ.validShapeF f
+
+validSize :: MinPQueue k a -> Bool
+validSize Empty = True
+validSize (MinPQ sz _ _ f) = sz == sizeH f + 1
+
+validOrder :: Ord k => MinPQueue k a -> Bool
+validOrder Empty = True
+validOrder (MinPQ _sz k _ f) = VBQ.precedesProperlyF k f
+
+sizeH :: BinomHeap k a -> Int
+sizeH = go 0 1
+  where
+    go :: Int -> Int -> BinomForest rk k a -> Int
+    go acc rk Nil = rk `seq` acc
+    go acc rk (Skip f) = go acc (2 * rk) f
+    go acc rk (Cons _t f) = go (acc + rk) (2 * rk) f


### PR DESCRIPTION
Shrink the queue spine in `extractBin` when its size drops from a power of two.

Fixes #108