### PR TITLE
Fix mapMaybe and mapEither

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## 1.5.0
 
+  * Fix incorrect behavior of `mapMaybe` and `mapEither` for `MinQueue`. These
+    previously worked only for monotonic functions.
+
+  * Fix a performance bug that caused queue performance not to improve
+    when the queue shrinks.
+    ([#109](https://github.com/lspitzner/pqueue/pull/109))
+
+  * Make `minView` more eager, improving performance in typical cases.
+    ([#107](https://github.com/lspitzner/pqueue/pull/107))
+
   * Make mapping and traversal functions force the full data structure spine.
     This should make performance more predictable, and removes the last
     remaining reasons to use the `seqSpine` functions. As these are no longer

--- a/benchmarks/BenchMinQueue.hs
+++ b/benchmarks/BenchMinQueue.hs
@@ -3,6 +3,7 @@ import Test.Tasty.Bench
 
 import qualified KWay.MergeAlg as KWay
 import qualified HeapSort as HS
+import qualified Data.PQueue.Min as P
 
 kWay :: Int -> Int -> Benchmark
 kWay i n = bench
@@ -14,9 +15,19 @@ hSort n = bench
   ("Heap sort with " ++ show n ++ " elements")
   (nf (HS.heapSortRandoms n) $ mkStdGen (-7750349139967535027))
 
+filterQ :: Int -> Benchmark
+filterQ n = bench
+  ("filter with " ++ show n ++ " elements")
+  (whnf (P.drop 1 . P.filter (>0) . (P.fromList :: [Int] -> P.MinQueue Int) . take n . randoms) $ mkStdGen 977209486631198655)
+
+partitionQ :: Int -> Benchmark
+partitionQ n = bench
+  ("partition with " ++ show n ++ " elements")
+  (whnf (P.drop 1 . snd . P.partition (>0) . (P.fromList :: [Int] -> P.MinQueue Int) . take n . randoms) $ mkStdGen 781928047937198)
+
 main :: IO ()
-main = defaultMain
-  [ bgroup "heapSort"
+main = defaultMain [
+    bgroup "heapSort"
       [ hSort (10^3)
       , hSort (10^4)
       , hSort (10^5)
@@ -34,5 +45,19 @@ main = defaultMain
       , kWay (3*10^6) 1000
       , kWay (2*10^6) 2000
       , kWay (4*10^6) 100
+      ]
+  , bgroup "filter"
+      [ filterQ (10^3)
+      , filterQ (10^4)
+      , filterQ (10^5)
+      , filterQ (10^6)
+      , filterQ (3*10^6)
+      ]
+  , bgroup "partition"
+      [ partitionQ (10^3)
+      , partitionQ (10^4)
+      , partitionQ (10^5)
+      , partitionQ (10^6)
+      , partitionQ (3*10^6)
       ]
   ]

--- a/pqueue.cabal
+++ b/pqueue.cabal
@@ -72,7 +72,6 @@ test-suite test
   main-is: PQueueTests.hs
   build-depends:
   { base >= 4.8 && < 4.19
-  , containers
   , deepseq >= 1.3 && < 1.5
   , indexed-traversable >= 0.1 && < 0.2
   , tasty

--- a/src/Data/PQueue/Internals.hs
+++ b/src/Data/PQueue/Internals.hs
@@ -185,7 +185,7 @@ unions = foldl' union empty
 -- | \(O(n)\). Map elements and collect the 'Just' results.
 mapMaybe :: Ord b => (a -> Maybe b) -> MinQueue a -> MinQueue b
 mapMaybe _ Empty = Empty
-mapMaybe f (MinQueue _ x ts) = fromBare $ maybe q' (`BQ.insert` q') (f x)
+mapMaybe f (MinQueue _ x ts) = fromBare $ maybe q' (`BQ.insertEager` q') (f x)
   where
     q' = BQ.mapMaybe f ts
 
@@ -195,8 +195,14 @@ mapEither _ Empty = (Empty, Empty)
 mapEither f (MinQueue _ x ts)
   | (l, r) <- BQ.mapEither f ts
   = case f x of
-      Left y -> (fromBare (BQ.insert y l), fromBare r)
-      Right z -> (fromBare l, fromBare (BQ.insert z r))
+      Left y ->
+        let !l' = fromBare (BQ.insertEager y l)
+            !r' = fromBare r
+        in (l', r')
+      Right z ->
+        let !l' = fromBare l
+            !r' = fromBare (BQ.insertEager z r)
+        in (l', r')
 
 -- | \(O(n)\). Assumes that the function it is given is monotonic, and applies this function to every element of the priority queue,
 -- as in 'fmap'. If it is not, the result is undefined.

--- a/src/Data/PQueue/Prio/Min.hs
+++ b/src/Data/PQueue/Prio/Min.hs
@@ -143,13 +143,6 @@ import qualified Data.PQueue.Prio.Internals as Internals
 import Prelude hiding (map, filter, break, span, takeWhile, dropWhile, splitAt, take, drop, (!!), null)
 
 #ifdef __GLASGOW_HASKELL__
-import GHC.Exts (build)
-#else
-build :: ((a -> [a] -> [a]) -> [a] -> [a]) -> [a]
-build f = f (:) []
-#endif
-
-#ifdef __GLASGOW_HASKELL__
 -- | A bidirectional pattern synonym for an empty priority queue.
 --
 -- @since 1.5.0


### PR DESCRIPTION
* Fix incorrect behavior of `mapMaybe` and `mapEither` for `MinQueue`.

To do:

- [x] Add tests.
- [x] Port all these changes to `MinPQueue`.

Fixes #110.