### PR TITLE
Replace `mapU` by `mapMonotonic`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Revision history for pqueue
 
+## x.x.x.x
+
+  * Deprecate `mapU` and replace it by `mapMonotonic` in `Data.PQeueu.Min` and `Data.PQueue.Max`
+    ([#129](https://github.com/lspitzner/pqueue/pull/129))
+
 ## 1.5.0.0 -- 2023-08-08
 
   * Fix incorrect behavior of `mapMaybe` and `mapEither` for `MinQueue`. These
@@ -24,12 +29,12 @@
     slow. ([#35](https://github.com/lspitzner/pqueue/issues/35))
 
   * Add pattern synonyms to work with `MinQueue` and `MinPQueue`.
-    ([#92](http://github.com/lspitzner/pqueue/pull/92))
+    ([#92](https://github.com/lspitzner/pqueue/pull/92))
 
   * Make the `Data` instances respect the queue invariants. Make the
     `Constr`s match the pattern synonyms. Make the `Data` instance for
     `MinPQueue` work "incrementally", like the one for `MinQueue`.
-    ([#92](http://github.com/lspitzner/pqueue/pull/92))
+    ([#92](https://github.com/lspitzner/pqueue/pull/92))
 
 ## 1.4.3.0 -- 2022-10-30
 

--- a/src/BinomialQueue/Min.hs
+++ b/src/BinomialQueue/Min.hs
@@ -62,6 +62,7 @@ module BinomialQueue.Min (
   mapEither,
   -- * Fold\/Functor\/Traversable variations
   map,
+  mapMonotonic,
   foldrAsc,
   foldlAsc,
   foldrDesc,
@@ -74,7 +75,6 @@ module BinomialQueue.Min (
   fromAscList,
   fromDescList,
   -- * Unordered operations
-  mapU,
   foldrU,
   foldlU,
   foldlU',

--- a/src/Data/PQueue/Internals.hs
+++ b/src/Data/PQueue/Internals.hs
@@ -29,7 +29,6 @@ module Data.PQueue.Internals (
   toDescList,
   toListU,
   fromList,
-  mapU,
   fromAscList,
   foldMapU,
   foldrU,
@@ -204,10 +203,13 @@ mapEither f (MinQueue _ x ts)
             !r' = fromBare (BQ.insertEager z r)
         in (l', r')
 
--- | \(O(n)\). Assumes that the function it is given is monotonic, and applies this function to every element of the priority queue,
--- as in 'fmap'. If it is not, the result is undefined.
+-- | \(O(n)\). Assumes that the function it is given is (weakly) monotonic
+-- (meaning that @x <= y@ implies @f x <= f y@), and
+-- applies this function to every element of the priority queue, as in 'fmap'.
+-- If the function is not monotonic, the result is undefined.
 mapMonotonic :: (a -> b) -> MinQueue a -> MinQueue b
-mapMonotonic = mapU
+mapMonotonic _ Empty = Empty
+mapMonotonic f (MinQueue n x ts) = MinQueue n (f x) (BQ.mapMonotonic f ts)
 
 {-# INLINABLE [0] foldrAsc #-}
 -- | \(O(n \log n)\). Performs a right fold on the elements of a priority queue in
@@ -294,13 +296,6 @@ fromList :: Ord a => [a] -> MinQueue a
 -- Why not just build the 'MinQueue' directly? This way saves us one
 -- comparison per element.
 fromList xs = fromBare (BQ.fromList xs)
-
--- | \(O(n)\). Assumes that the function it is given is (weakly) monotonic, and
--- applies this function to every element of the priority queue, as in 'fmap'.
--- If the function is not monotonic, the result is undefined.
-mapU :: (a -> b) -> MinQueue a -> MinQueue b
-mapU _ Empty = Empty
-mapU f (MinQueue n x ts) = MinQueue n (f x) (BQ.mapU f ts)
 
 {-# NOINLINE [0] foldrU #-}
 -- | \(O(n)\). Unordered right fold on a priority queue.

--- a/src/Data/PQueue/Max.hs
+++ b/src/Data/PQueue/Max.hs
@@ -59,6 +59,7 @@ module Data.PQueue.Max (
   mapEither,
   -- * Fold\/Functor\/Traversable variations
   map,
+  mapMonotonic,
   foldrAsc,
   foldlAsc,
   foldrDesc,
@@ -274,10 +275,16 @@ mapEither f (MaxQ q) = (MaxQ q0, MaxQ q1)
 map :: Ord b => (a -> b) -> MaxQueue a -> MaxQueue b
 map f (MaxQ q) = MaxQ (Min.map (\(Down x) -> Down (f x)) q)
 
--- | \(O(n)\). Assumes that the function it is given is monotonic, and applies this function to every element of the priority queue.
--- /Does not check the precondition/.
+-- | \(O(n)\). Assumes that the function it is given is (weakly) monotonic
+-- (meaning that @x <= y@ implies @f x <= f y@), and
+-- applies this function to every element of the priority queue, as in 'fmap'.
+-- If the function is not monotonic, the result is undefined.
+mapMonotonic :: (a -> b) -> MaxQueue a -> MaxQueue b
+mapMonotonic f (MaxQ q) = MaxQ (Min.mapMonotonic (\(Down a) -> Down (f a)) q)
+
+{-# DEPRECATED mapU "use mapMonotonic instead" #-}
 mapU :: (a -> b) -> MaxQueue a -> MaxQueue b
-mapU f (MaxQ q) = MaxQ (Min.mapU (\(Down a) -> Down (f a)) q)
+mapU = mapMonotonic
 
 -- | \(O(n)\). Unordered right fold on a priority queue.
 foldrU :: (a -> b -> b) -> b -> MaxQueue a -> b

--- a/src/Data/PQueue/Min.hs
+++ b/src/Data/PQueue/Min.hs
@@ -68,6 +68,7 @@ module Data.PQueue.Min (
   mapEither,
   -- * Fold\/Functor\/Traversable variations
   map,
+  mapMonotonic,
   foldrAsc,
   foldlAsc,
   foldrDesc,
@@ -231,6 +232,10 @@ partition p = mapEither (\x -> if p x then Left x else Right x)
 -- Equivalent to @'fromList' . 'Data.List.map' f . toList@.
 map :: Ord b => (a -> b) -> MinQueue a -> MinQueue b
 map f = foldrU (insert . f) empty
+
+{-# DEPRECATED mapU "use mapMonotonic instead" #-}
+mapU :: (a -> b) -> MinQueue a -> MinQueue b
+mapU = mapMonotonic
 
 {-# INLINE toList #-}
 -- | \(O(n \log n)\). Returns the elements of the priority queue in ascending order. Equivalent to 'toAscList'.

--- a/src/Data/PQueue/Prio/Internals.hs
+++ b/src/Data/PQueue/Prio/Internals.hs
@@ -313,8 +313,8 @@ mapWithKey :: (k -> a -> b) -> MinPQueue k a -> MinPQueue k b
 mapWithKey f = runIdentity . traverseWithKeyU (coerce f)
 
 -- | \(O(n)\). @'mapKeysMonotonic' f q == 'mapKeys' f q@, but only works when
--- @f@ is (weakly) monotonic. /The precondition is not checked./ This function
--- has better performance than 'mapKeys'.
+-- @f@ is (weakly) monotonic (meaning that @x <= y@ implies @f x <= f y@).
+-- /The precondition is not checked./ This function has better performance than 'mapKeys'.
 --
 -- Note: if the given function returns bottom for any of the keys in the queue, then the
 -- portion of the queue which is bottom is /unspecified/.

--- a/src/Data/PQueue/Prio/Max/Internals.hs
+++ b/src/Data/PQueue/Prio/Max/Internals.hs
@@ -339,9 +339,12 @@ mapWithKey f (MaxPQ q) = MaxPQ (Q.mapWithKey (f . unDown) q)
 mapKeys :: Ord k' => (k -> k') -> MaxPQueue k a -> MaxPQueue k' a
 mapKeys f (MaxPQ q) = MaxPQ (Q.mapKeys (fmap f) q)
 
--- | \(O(n)\). @'mapKeysMonotonic' f q == 'mapKeys' f q@, but only works when @f@ is strictly
--- monotonic. /The precondition is not checked./ This function has better performance than
--- 'mapKeys'.
+-- | \(O(n)\). @'mapKeysMonotonic' f q == 'mapKeys' f q@, but only works when
+-- @f@ is (weakly) monotonic (meaning that @x <= y@ implies @f x <= f y@).
+-- /The precondition is not checked./ This function has better performance than 'mapKeys'.
+--
+-- Note: if the given function returns bottom for any of the keys in the queue, then the
+-- portion of the queue which is bottom is /unspecified/.
 mapKeysMonotonic :: (k -> k') -> MaxPQueue k a -> MaxPQueue k' a
 mapKeysMonotonic f (MaxPQ q) = MaxPQ (Q.mapKeysMonotonic (fmap f) q)
 

--- a/tests/PQueueTests.hs
+++ b/tests/PQueueTests.hs
@@ -74,6 +74,14 @@ main = defaultMain $ testGroup "pqueue"
            validMinQueue zs .&&.
            (Min.toList ys, Min.toList zs) === bimap List.sort List.sort (Either.partitionEithers . List.map f $ xs)
     , testProperty "map" $ \xs -> Min.map negate (Min.fromList xs) === Min.fromList (List.map negate xs)
+    , testProperty "mapMonotonic" $ \xs ->
+        let
+          -- Monotonic, but not strictly so
+          fun x
+            | even x = x
+            | otherwise = x + 1
+          res = Min.mapMonotonic fun (Min.fromList xs)
+        in validMinQueue res .&&. Min.toList res === List.map fun (List.sort xs)
     , testProperty "take" $ \n xs -> Min.take n (Min.fromList xs) === List.take n (List.sort xs)
     , testProperty "drop" $ \n xs -> Min.drop n (Min.fromList xs) === Min.fromList (List.drop n (List.sort xs))
     , testProperty "splitAt" $ \n xs -> Min.splitAt n (Min.fromList xs) === second Min.fromList (List.splitAt n (List.sort xs))
@@ -88,14 +96,6 @@ main = defaultMain $ testGroup "pqueue"
     , testProperty "toDescList" $ \xs -> Min.toDescList (Min.fromList xs) === List.sortOn Down xs
     , testProperty "fromAscList" $ \xs -> Min.fromAscList (List.sort xs) === Min.fromList xs
     , testProperty "fromDescList" $ \xs -> Min.fromDescList (List.sortOn Down xs) === Min.fromList xs
-    , testProperty "mapU" $ \xs ->
-        let
-          -- Monotonic, but not strictly so
-          fun x
-            | even x = x
-            | otherwise = x + 1
-          res = Min.mapU fun (Min.fromList xs)
-        in validMinQueue res .&&. Min.toList res === List.map fun (List.sort xs)
     , testProperty "foldrU" $ \xs -> Min.foldrU (+) 0 (Min.fromList xs) === sum xs
     , testProperty "foldlU" $ \xs -> Min.foldlU (+) 0 (Min.fromList xs) === sum xs
     , testProperty "foldlU'" $ \xs -> Min.foldlU' (+) 0 (Min.fromList xs) === sum xs
@@ -115,6 +115,7 @@ main = defaultMain $ testGroup "pqueue"
     , testProperty "filter" $ \xs -> Max.filter even (Max.fromList xs) === Max.fromList (List.filter even xs)
     , testProperty "partition" $ \xs -> Max.partition even (Max.fromList xs) === bimap Max.fromList Max.fromList (List.partition even xs)
     , testProperty "map" $ \xs -> Max.map negate (Max.fromList xs) === Max.fromList (List.map negate xs)
+    , testProperty "mapMonotonic" $ \xs -> Max.mapMonotonic (+ 1) (Max.fromList xs) === Max.fromList (List.map (+ 1) xs)
     , testProperty "take" $ \n xs -> Max.take n (Max.fromList xs) === List.take n (List.sortOn Down xs)
     , testProperty "drop" $ \n xs -> Max.drop n (Max.fromList xs) === Max.fromList (List.drop n (List.sortOn Down xs))
     , testProperty "splitAt" $ \n xs -> Max.splitAt n (Max.fromList xs) === second Max.fromList (List.splitAt n (List.sortOn Down xs))
@@ -129,7 +130,6 @@ main = defaultMain $ testGroup "pqueue"
     , testProperty "toDescList" $ \xs -> Max.toDescList (Max.fromList xs) === List.sortOn Down xs
     , testProperty "fromAscList" $ \xs -> Max.fromAscList (List.sort xs) === Max.fromList xs
     , testProperty "fromDescList" $ \xs -> Max.fromDescList (List.sortOn Down xs) === Max.fromList xs
-    , testProperty "mapU" $ \xs -> Max.mapU (+ 1) (Max.fromList xs) === Max.fromList (List.map (+ 1) xs)
     , testProperty "foldrU" $ \xs -> Max.foldrU (+) 0 (Max.fromList xs) === sum xs
     , testProperty "foldlU" $ \xs -> Max.foldlU (+) 0 (Max.fromList xs) === sum xs
     , testProperty "foldlU'" $ \xs -> Max.foldlU' (+) 0 (Max.fromList xs) === sum xs


### PR DESCRIPTION
Deprecate `mapU` and replace it by `mapMonotonic`. Update the documentation for `mapMonotonic` and `mapKeysMonotonic`. 

Closes #122.