### PR TITLE
Fix unused imports and other warnings

### DIFF
--- a/benchmarks/HeapSort.hs
+++ b/benchmarks/HeapSort.hs
@@ -1,6 +1,5 @@
 module HeapSort where
 
-import Data.PQueue.Min (MinQueue)
 import qualified Data.PQueue.Min as P
 import System.Random
 

--- a/benchmarks/KWay/PrioMergeAlg.hs
+++ b/benchmarks/KWay/PrioMergeAlg.hs
@@ -7,7 +7,6 @@ module KWay.PrioMergeAlg
   ) where
 
 import qualified Data.PQueue.Prio.Min as P
-import System.Random (StdGen)
 import Data.Word
 import Data.List (unfoldr)
 import KWay.RandomIncreasing

--- a/benchmarks/KWay/RandomIncreasing.hs
+++ b/benchmarks/KWay/RandomIncreasing.hs
@@ -5,7 +5,6 @@ module KWay.RandomIncreasing where
 
 import System.Random
 import Data.Word
-import Data.List (unfoldr)
 
 data Stream = Stream !Word64 {-# UNPACK #-} !StdGen
 

--- a/benchmarks/PHeapSort.hs
+++ b/benchmarks/PHeapSort.hs
@@ -1,6 +1,5 @@
 module PHeapSort where
 
-import Data.PQueue.Prio.Min (MinPQueue)
 import qualified Data.PQueue.Prio.Min as P
 import System.Random
 

--- a/pqueue.cabal
+++ b/pqueue.cabal
@@ -74,9 +74,6 @@ library
     -fspec-constr
     -fdicts-strict
     -Wall
-  if impl(ghc >= 8.0)
-    ghc-options:
-      -fno-warn-unused-imports
 
 test-suite test
   hs-source-dirs: src, tests

--- a/src/BinomialQueue/Internals.hs
+++ b/src/BinomialQueue/Internals.hs
@@ -46,7 +46,9 @@ module BinomialQueue.Internals (
   ) where
 
 import Control.DeepSeq (NFData(rnf), deepseq)
+#if !MIN_VERSION_base(4,20,0)
 import Data.Foldable (foldl')
+#endif
 import Data.Function (on)
 #if MIN_VERSION_base(4,9,0)
 import Data.Semigroup (Semigroup(..), stimesMonoid)

--- a/src/BinomialQueue/Max.hs
+++ b/src/BinomialQueue/Max.hs
@@ -88,25 +88,12 @@ module BinomialQueue.Max (
 import Prelude hiding (null, take, drop, takeWhile, dropWhile, splitAt, span, break, (!!), filter, map)
 
 import Data.Coerce (coerce)
-import Data.Foldable (foldl')
-import Data.Maybe (fromMaybe)
 import Data.Bifunctor (bimap)
-
-#if MIN_VERSION_base(4,9,0)
-import Data.Semigroup (Semigroup((<>)))
-#endif
-
 import qualified Data.List as List
+import Data.Maybe (fromMaybe)
 
 import qualified BinomialQueue.Min as MinQ
 import Data.PQueue.Internals.Down
-
-#ifdef __GLASGOW_HASKELL__
-import GHC.Exts (build)
-#else
-build :: ((a -> [a] -> [a]) -> [a] -> [a]) -> [a]
-build f = f (:) []
-#endif
 
 newtype MaxQueue a = MaxQueue { unMaxQueue :: MinQ.MinQueue (Down a) }
 

--- a/src/BinomialQueue/Min.hs
+++ b/src/BinomialQueue/Min.hs
@@ -88,7 +88,9 @@ module BinomialQueue.Min (
 
 import Prelude hiding (null, take, drop, takeWhile, dropWhile, splitAt, span, break, (!!), filter, map)
 
+#if !MIN_VERSION_base(4,20,0)
 import Data.Foldable (foldl')
+#endif
 import qualified Data.List as List
 import Data.Maybe (fromMaybe)
 

--- a/src/BinomialQueue/Min.hs
+++ b/src/BinomialQueue/Min.hs
@@ -89,22 +89,10 @@ module BinomialQueue.Min (
 import Prelude hiding (null, take, drop, takeWhile, dropWhile, splitAt, span, break, (!!), filter, map)
 
 import Data.Foldable (foldl')
+import qualified Data.List as List
 import Data.Maybe (fromMaybe)
 
-#if MIN_VERSION_base(4,9,0)
-import Data.Semigroup (Semigroup((<>)))
-#endif
-
-import qualified Data.List as List
-
 import BinomialQueue.Internals
-
-#ifdef __GLASGOW_HASKELL__
-import GHC.Exts (build)
-#else
-build :: ((a -> [a] -> [a]) -> [a] -> [a]) -> [a]
-build f = f (:) []
-#endif
 
 -- | \(O(\log n)\). Returns the minimum element. Throws an error on an empty queue.
 findMin :: Ord a => MinQueue a -> a

--- a/src/Data/PQueue/Internals.hs
+++ b/src/Data/PQueue/Internals.hs
@@ -48,7 +48,9 @@ import BinomialQueue.Internals
   )
 import qualified BinomialQueue.Internals as BQ
 import Control.DeepSeq (NFData(rnf), deepseq)
+#if !MIN_VERSION_base(4,20,0)
 import Data.Foldable (foldl')
+#endif
 #if MIN_VERSION_base(4,9,0)
 import Data.Semigroup (Semigroup(..), stimesMonoid)
 #endif

--- a/src/Data/PQueue/Internals.hs
+++ b/src/Data/PQueue/Internals.hs
@@ -45,8 +45,6 @@ import BinomialQueue.Internals
   , BinomTree (..)
   , Succ (..)
   , Zero (..)
-  , Extract (..)
-  , MExtract (..)
   )
 import qualified BinomialQueue.Internals as BQ
 import Control.DeepSeq (NFData(rnf), deepseq)
@@ -55,7 +53,6 @@ import Data.Foldable (foldl')
 import Data.Semigroup (Semigroup(..), stimesMonoid)
 #endif
 
-import Data.PQueue.Internals.Foldable
 #ifdef __GLASGOW_HASKELL__
 import Data.Data
 import Text.Read (Lexeme(Ident), lexP, parens, prec,

--- a/src/Data/PQueue/Max.hs
+++ b/src/Data/PQueue/Max.hs
@@ -86,13 +86,13 @@ module Data.PQueue.Max (
 import Control.DeepSeq (NFData(rnf))
 
 import Data.Coerce (coerce)
+#if !MIN_VERSION_base(4,20,0)
+import Data.Foldable (foldl')
+#endif
 import Data.Maybe (fromMaybe)
-
 #if MIN_VERSION_base(4,9,0)
 import Data.Semigroup (Semigroup(..), stimesMonoid)
 #endif
-
-import Data.Foldable (foldl')
 
 import qualified Data.PQueue.Min as Min
 import qualified Data.PQueue.Prio.Max.Internals as Prio

--- a/src/Data/PQueue/Min.hs
+++ b/src/Data/PQueue/Min.hs
@@ -94,7 +94,9 @@ module Data.PQueue.Min (
 
 import Prelude hiding (null, take, drop, takeWhile, dropWhile, splitAt, span, break, (!!), filter, map)
 
+#if !MIN_VERSION_base(4,20,0)
 import Data.Foldable (foldl')
+#endif
 import qualified Data.List as List
 import Data.Maybe (fromMaybe)
 

--- a/src/Data/PQueue/Min.hs
+++ b/src/Data/PQueue/Min.hs
@@ -95,26 +95,14 @@ module Data.PQueue.Min (
 import Prelude hiding (null, take, drop, takeWhile, dropWhile, splitAt, span, break, (!!), filter, map)
 
 import Data.Foldable (foldl')
-import Data.Maybe (fromMaybe)
-
-#if MIN_VERSION_base(4,9,0)
-import Data.Semigroup (Semigroup((<>)))
-#endif
-
 import qualified Data.List as List
+import Data.Maybe (fromMaybe)
 
 import Data.PQueue.Internals hiding (MinQueue (..))
 import Data.PQueue.Internals (MinQueue (MinQueue))
 import qualified Data.PQueue.Internals as Internals
 import qualified BinomialQueue.Internals as BQ
 import qualified Data.PQueue.Prio.Internals as Prio
-
-#ifdef __GLASGOW_HASKELL__
-import GHC.Exts (build)
-#else
-build :: ((a -> [a] -> [a]) -> [a] -> [a]) -> [a]
-build f = f (:) []
-#endif
 
 #ifdef __GLASGOW_HASKELL__
 -- | A bidirectional pattern synonym for an empty priority queue.

--- a/src/Data/PQueue/Min.hs
+++ b/src/Data/PQueue/Min.hs
@@ -136,7 +136,9 @@ pattern a :< q <- (minView -> Just (a, q))
 {-# INLINE (:<) #-}
 # endif
 
+# if __GLASGOW_HASKELL__ >= 820
 {-# COMPLETE Empty, (:<) #-}
+# endif
 #endif
 
 -- | \(O(1)\). Returns the minimum element. Throws an error on an empty queue.

--- a/src/Data/PQueue/Prio/Internals.hs
+++ b/src/Data/PQueue/Prio/Internals.hs
@@ -52,7 +52,11 @@ module Data.PQueue.Prio.Internals (
   unions
   ) where
 
-import Control.Applicative (liftA2, liftA3, Const (..))
+#if MIN_VERSION_base(4,18,0)
+import Control.Applicative (Const (..))
+#else
+import Control.Applicative (liftA2, Const (..))
+#endif
 import Control.DeepSeq (NFData(rnf), deepseq)
 import Data.Coerce (coerce)
 import Data.Functor.Identity (Identity(Identity, runIdentity))

--- a/src/Data/PQueue/Prio/Min.hs
+++ b/src/Data/PQueue/Prio/Min.hs
@@ -132,10 +132,6 @@ module Data.PQueue.Prio.Min (
 import qualified Data.List as List
 import Data.Maybe (fromMaybe)
 
-#if MIN_VERSION_base(4,9,0)
-import Data.Semigroup (Semigroup((<>)))
-#endif
-
 import Data.PQueue.Prio.Internals hiding (MinPQueue (..))
 import Data.PQueue.Prio.Internals (MinPQueue)
 import qualified Data.PQueue.Prio.Internals as Internals

--- a/src/Data/PQueue/Prio/Min.hs
+++ b/src/Data/PQueue/Prio/Min.hs
@@ -168,7 +168,9 @@ pattern ka :< q <- (minViewWithKey -> Just (ka, q))
 {-# INLINE (:<) #-}
 # endif
 
+# if __GLASGOW_HASKELL__ >= 820
 {-# COMPLETE Empty, (:<) #-}
+# endif
 #endif
 
 (.:) :: (c -> d) -> (a -> b -> c) -> a -> b -> d

--- a/src/Nattish.hs
+++ b/src/Nattish.hs
@@ -18,7 +18,9 @@ module Nattish
   ( Nattish (Zeroy, Succy)
   )
   where
+#if __GLASGOW_HASKELL__ >= 904
 import Unsafe.Coerce (unsafeCoerce)
+#endif
 #if __GLASGOW_HASKELL__ >= 800
 import Data.Kind (Type)
 #endif

--- a/src/Nattish.hs
+++ b/src/Nattish.hs
@@ -40,7 +40,11 @@ import Data.Kind (Type)
 -- it is very fast to work with.
 
 #if __GLASGOW_HASKELL__ < 904
+#if __GLASGOW_HASKELL__ >= 800
+data Nattish :: k -> (k -> k) -> k -> Type where
+#else
 data Nattish :: k -> (k -> k) -> k -> * where
+#endif
   Zeroy :: Nattish zero succ zero
   Succy :: !(Nattish zero succ n) -> Nattish zero succ (succ n)
 


### PR DESCRIPTION
This PR re-enables `Wunused-imports` and removes all unused imports.

We also use CPP to fix a few more warnings that only appear on some GHCs.