### PR TITLE
More `coerce`

### DIFF
--- a/src/BinomialQueue/Max.hs
+++ b/src/BinomialQueue/Max.hs
@@ -88,7 +88,6 @@ module BinomialQueue.Max (
 import Prelude hiding (null, take, drop, takeWhile, dropWhile, splitAt, span, break, (!!), filter, map)
 
 import Data.Coerce (coerce)
-import Data.Bifunctor (bimap)
 import qualified Data.List as List
 import Data.Maybe (fromMaybe)
 
@@ -103,11 +102,11 @@ findMax = fromMaybe (error "Error: findMax called on empty queue") . getMax
 
 -- | \(O(1)\). The top (maximum) element of the queue, if there is one.
 getMax :: Ord a => MaxQueue a -> Maybe a
-getMax (MaxQueue q) = unDown <$> MinQ.getMin q
+getMax = coerce MinQ.getMin
 
 -- | \(O(\log n)\). Deletes the maximum element. If the queue is empty, does nothing.
 deleteMax :: Ord a => MaxQueue a -> MaxQueue a
-deleteMax = MaxQueue . MinQ.deleteMin . unMaxQueue
+deleteMax = coerce MinQ.deleteMin
 
 -- | \(O(\log n)\). Extracts the maximum element. Throws an error on an empty queue.
 deleteFindMax :: Ord a => MaxQueue a -> (a, MaxQueue a)
@@ -115,9 +114,7 @@ deleteFindMax = fromMaybe (error "Error: deleteFindMax called on empty queue") .
 
 -- | \(O(\log n)\). Extract the top (maximum) element of the sequence, if there is one.
 maxView :: Ord a => MaxQueue a -> Maybe (a, MaxQueue a)
-maxView (MaxQueue q) = case MinQ.minView q of
-  Just (Down a, q') -> Just (a, MaxQueue q')
-  Nothing -> Nothing
+maxView = coerce MinQ.minView
 
 -- | \(O(k \log n)\). Index (subscript) operator, starting from 0. @queue !! k@ returns the @(k+1)@th largest
 -- element in the queue. Equivalent to @toDescList queue !! k@.
@@ -130,19 +127,17 @@ q !! n = toDescList q List.!! n
 -- | 'takeWhile', applied to a predicate @p@ and a queue @queue@, returns the
 -- longest prefix (possibly empty) of @queue@ of elements that satisfy @p@.
 takeWhile :: Ord a => (a -> Bool) -> MaxQueue a -> [a]
-takeWhile p = coerce . MinQ.takeWhile (p . unDown) . unMaxQueue
+takeWhile = coerce MinQ.takeWhile
 
 -- | 'dropWhile' @p queue@ returns the queue remaining after 'takeWhile' @p queue@.
 dropWhile :: Ord a => (a -> Bool) -> MaxQueue a -> MaxQueue a
-dropWhile p = MaxQueue . MinQ.dropWhile (p . unDown) . unMaxQueue
+dropWhile = coerce MinQ.dropWhile
 
 -- | 'span', applied to a predicate @p@ and a queue @queue@, returns a tuple where
 -- first element is longest prefix (possibly empty) of @queue@ of elements that
 -- satisfy @p@ and second element is the remainder of the queue.
 span :: Ord a => (a -> Bool) -> MaxQueue a -> ([a], MaxQueue a)
-span p (MaxQueue queue)
-  | (front, rear) <- MinQ.span (p . unDown) queue
-  = (coerce front, MaxQueue rear)
+span = coerce MinQ.span
 
 -- | 'break', applied to a predicate @p@ and a queue @queue@, returns a tuple where
 -- first element is longest prefix (possibly empty) of @queue@ of elements that
@@ -159,73 +154,67 @@ take n = List.take n . toDescList
 -- | \(O(k \log n)\). 'drop' @k@, applied to a queue @queue@, returns @queue@ with the greatest @k@ elements deleted,
 -- or an empty queue if @k >= 'size' queue@.
 drop :: Ord a => Int -> MaxQueue a -> MaxQueue a
-drop n (MaxQueue queue) = MaxQueue (MinQ.drop n queue)
+drop = coerce MinQ.drop
 
 -- | \(O(k \log n)\). Equivalent to @('take' k queue, 'drop' k queue)@.
 splitAt :: Ord a => Int -> MaxQueue a -> ([a], MaxQueue a)
-splitAt n (MaxQueue queue)
-  | (l, r) <- MinQ.splitAt n queue
-  = (coerce l, MaxQueue r)
+splitAt = coerce MinQ.splitAt
 
 -- | \(O(n)\). Returns the queue with all elements not satisfying @p@ removed.
 filter :: Ord a => (a -> Bool) -> MaxQueue a -> MaxQueue a
-filter p = MaxQueue . MinQ.filter (p . unDown) . unMaxQueue
+filter = coerce MinQ.filter
 
 -- | \(O(n)\). Returns a pair where the first queue contains all elements satisfying @p@, and the second queue
 -- contains all elements not satisfying @p@.
 partition :: Ord a => (a -> Bool) -> MaxQueue a -> (MaxQueue a, MaxQueue a)
-partition p = go . unMaxQueue
-  where
-    go queue
-      | (l, r) <- MinQ.partition (p . unDown) queue
-      = (MaxQueue l, MaxQueue r)
+partition = coerce MinQ.partition
 
 -- | \(O(n)\). Creates a new priority queue containing the images of the elements of this queue.
 -- Equivalent to @'fromList' . 'Data.List.map' f . toList@.
 map :: Ord b => (a -> b) -> MaxQueue a -> MaxQueue b
-map f = MaxQueue . MinQ.map (fmap f) . unMaxQueue
+map = coerce MinQ.map
 
 {-# INLINE toList #-}
 -- | \(O(n \log n)\). Returns the elements of the priority queue in descending order. Equivalent to 'toDescList'.
 --
 -- If the order of the elements is irrelevant, consider using 'toListU'.
 toList :: Ord a => MaxQueue a -> [a]
-toList = coerce . MinQ.toAscList . unMaxQueue
+toList = coerce MinQ.toAscList
 
 toAscList :: Ord a => MaxQueue a -> [a]
-toAscList = coerce . MinQ.toDescList . unMaxQueue
+toAscList = coerce MinQ.toDescList
 
 toDescList :: Ord a => MaxQueue a -> [a]
-toDescList = coerce . MinQ.toAscList . unMaxQueue
+toDescList = coerce MinQ.toAscList
 
 -- | \(O(n \log n)\). Performs a right fold on the elements of a priority queue in descending order.
 foldrDesc :: Ord a => (a -> b -> b) -> b -> MaxQueue a -> b
-foldrDesc f z (MaxQueue q) = MinQ.foldrAsc (flip (foldr f)) z q
+foldrDesc f z (MaxQueue q) = MinQ.foldrAsc (coerce f) z q
 
 -- | \(O(n \log n)\). Performs a right fold on the elements of a priority queue in ascending order.
 foldrAsc :: Ord a => (a -> b -> b) -> b -> MaxQueue a -> b
-foldrAsc f z (MaxQueue q) = MinQ.foldrDesc (flip (foldr f)) z q
+foldrAsc f z (MaxQueue q) = MinQ.foldrDesc (coerce f) z q
 
 -- | \(O(n \log n)\). Performs a left fold on the elements of a priority queue in ascending order.
 foldlAsc :: Ord a => (b -> a -> b) -> b -> MaxQueue a -> b
-foldlAsc f z (MaxQueue q) = MinQ.foldlDesc (foldl f) z q
+foldlAsc f z (MaxQueue q) = MinQ.foldlDesc (coerce f) z q
 
 -- | \(O(n \log n)\). Performs a left fold on the elements of a priority queue in descending order.
 foldlDesc :: Ord a => (b -> a -> b) -> b -> MaxQueue a -> b
-foldlDesc f z (MaxQueue q) = MinQ.foldlAsc (foldl f) z q
+foldlDesc f z (MaxQueue q) = MinQ.foldlAsc (coerce f) z q
 
 {-# INLINE fromAscList #-}
 -- | \(O(n)\). Constructs a priority queue from an ascending list. /Warning/: Does not check the precondition.
 fromAscList :: [a] -> MaxQueue a
-fromAscList = MaxQueue . MinQ.fromDescList . coerce
+fromAscList = coerce MinQ.fromDescList
 
 {-# INLINE fromDescList #-}
 -- | \(O(n)\). Constructs a priority queue from a descending list. /Warning/: Does not check the precondition.
 fromDescList :: [a] -> MaxQueue a
-fromDescList = MaxQueue . MinQ.fromAscList . coerce
+fromDescList = coerce MinQ.fromAscList
 
 fromList :: Ord a => [a] -> MaxQueue a
-fromList = MaxQueue . MinQ.fromList . coerce
+fromList = coerce MinQ.fromList
 
 -- | Equivalent to 'toListU'.
 elemsU :: MaxQueue a -> [a]
@@ -233,7 +222,7 @@ elemsU = toListU
 
 -- | Convert to a list in an arbitrary order.
 toListU :: MaxQueue a -> [a]
-toListU = coerce . MinQ.toListU . unMaxQueue
+toListU = coerce MinQ.toListU
 
 -- | Get the number of elements in a 'MaxQueue'.
 size :: MaxQueue a -> Int
@@ -243,35 +232,34 @@ empty :: MaxQueue a
 empty = MaxQueue MinQ.empty
 
 foldMapU :: Monoid m => (a -> m) -> MaxQueue a -> m
-foldMapU f = MinQ.foldMapU (f . unDown) . unMaxQueue
+foldMapU f = MinQ.foldMapU (coerce f) . unMaxQueue
 
 seqSpine :: MaxQueue a -> b -> b
 seqSpine = MinQ.seqSpine . unMaxQueue
 
 foldlU :: (b -> a -> b) -> b -> MaxQueue a -> b
-foldlU f b = MinQ.foldlU (\acc (Down a) -> f acc a) b . unMaxQueue
+foldlU f b = MinQ.foldlU (coerce f) b . unMaxQueue
 
 foldlU' :: (b -> a -> b) -> b -> MaxQueue a -> b
-foldlU' f b = MinQ.foldlU' (\acc (Down a) -> f acc a) b . unMaxQueue
+foldlU' f b = MinQ.foldlU' (coerce f) b . unMaxQueue
 
 foldrU :: (a -> b -> b) -> b -> MaxQueue a -> b
-foldrU c n = MinQ.foldrU (c . unDown) n . unMaxQueue
+foldrU c n = MinQ.foldrU (coerce c) n . unMaxQueue
 
 null :: MaxQueue a -> Bool
 null = MinQ.null . unMaxQueue
 
 singleton :: a -> MaxQueue a
-singleton = MaxQueue . MinQ.singleton . Down
+singleton = coerce MinQ.singleton
 
 mapMaybe :: Ord b => (a -> Maybe b) -> MaxQueue a -> MaxQueue b
-mapMaybe f = MaxQueue . MinQ.mapMaybe (coerce f) . unMaxQueue
+mapMaybe = coerce MinQ.mapMaybe
 
 insert :: Ord a => a -> MaxQueue a -> MaxQueue a
-insert a (MaxQueue q) = MaxQueue (MinQ.insert (Down a) q)
+insert = coerce MinQ.insert
 
 mapEither :: (Ord b, Ord c) => (a -> Either b c) -> MaxQueue a -> (MaxQueue b, MaxQueue c)
-mapEither f (MaxQueue q) = case MinQ.mapEither (bimap Down Down . f . unDown) q of
-  (l, r) -> (MaxQueue l, MaxQueue r)
+mapEither = coerce MinQ.mapEither
 
 union :: Ord a => MaxQueue a -> MaxQueue a -> MaxQueue a
 union (MaxQueue a) (MaxQueue b) = MaxQueue (MinQ.union a b)

--- a/src/Data/PQueue/Max.hs
+++ b/src/Data/PQueue/Max.hs
@@ -169,11 +169,11 @@ findMax = fromMaybe (error "Error: findMax called on empty queue") . getMax
 
 -- | \(O(1)\). The top (maximum) element of the queue, if there is one.
 getMax :: MaxQueue a -> Maybe a
-getMax (MaxQ q) = unDown <$> Min.getMin q
+getMax = coerce Min.getMin
 
 -- | \(O(\log n)\). Deletes the maximum element of the queue. Does nothing on an empty queue.
 deleteMax :: Ord a => MaxQueue a -> MaxQueue a
-deleteMax (MaxQ q) = MaxQ (Min.deleteMin q)
+deleteMax = coerce Min.deleteMin
 
 -- | \(O(\log n)\). Extracts the maximum element of the queue. Throws an error on an empty queue.
 deleteFindMax :: Ord a => MaxQueue a -> (a, MaxQueue a)
@@ -181,10 +181,7 @@ deleteFindMax = fromMaybe (error "Error: deleteFindMax called on empty queue") .
 
 -- | \(O(\log n)\). Extract the top (maximum) element of the sequence, if there is one.
 maxView :: Ord a => MaxQueue a -> Maybe (a, MaxQueue a)
-maxView (MaxQ q) = case Min.minView q of
-  Nothing -> Nothing
-  Just (Down x, q')
-          -> Just (x, MaxQ q')
+maxView = coerce Min.minView
 
 -- | \(O(\log n)\). Delete the top (maximum) element of the sequence, if there is one.
 delete :: Ord a => MaxQueue a -> Maybe (MaxQueue a)
@@ -192,11 +189,11 @@ delete = fmap snd . maxView
 
 -- | \(O(1)\). Construct a priority queue with a single element.
 singleton :: a -> MaxQueue a
-singleton = MaxQ . Min.singleton . Down
+singleton = coerce Min.singleton
 
 -- | \(O(1)\). Insert an element into the priority queue.
 insert :: Ord a => a -> MaxQueue a -> MaxQueue a
-x `insert` MaxQ q = MaxQ (Down x `Min.insert` q)
+insert = coerce Min.insert
 
 -- | \(O(\log min(n_1,n_2))\). Take the union of two priority queues.
 union :: Ord a => MaxQueue a -> MaxQueue a -> MaxQueue a
@@ -204,43 +201,41 @@ MaxQ q1 `union` MaxQ q2 = MaxQ (q1 `Min.union` q2)
 
 -- | Takes the union of a list of priority queues. Equivalent to @'foldl' 'union' 'empty'@.
 unions :: Ord a => [MaxQueue a] -> MaxQueue a
-unions qs = MaxQ (Min.unions [q | MaxQ q <- qs])
+unions = coerce Min.unions
 
 -- | \(O(k \log n)\). Returns the @(k+1)@th largest element of the queue.
 (!!) :: Ord a => MaxQueue a -> Int -> a
-MaxQ q !! n = unDown ((Min.!!) q n)
+(!!) = coerce (Min.!!)
 
 {-# INLINE take #-}
 -- | \(O(k \log n)\). Returns the list of the @k@ largest elements of the queue, in descending order, or
 -- all elements of the queue, if @k >= n@.
 take :: Ord a => Int -> MaxQueue a -> [a]
-take k (MaxQ q) = [a | Down a <- Min.take k q]
+take = coerce Min.take
 
 -- | \(O(k \log n)\). Returns the queue with the @k@ largest elements deleted, or the empty queue if @k >= n@.
 drop :: Ord a => Int -> MaxQueue a -> MaxQueue a
-drop k (MaxQ q) = MaxQ (Min.drop k q)
+drop = coerce Min.drop
 
 -- | \(O(k \log n)\). Equivalent to @(take k queue, drop k queue)@.
 splitAt :: Ord a => Int -> MaxQueue a -> ([a], MaxQueue a)
-splitAt k (MaxQ q) = (coerce xs, MaxQ q') where
-  (xs, q') = Min.splitAt k q
+splitAt = coerce Min.splitAt
 
 -- | 'takeWhile', applied to a predicate @p@ and a queue @queue@, returns the
 -- longest prefix (possibly empty) of @queue@ of elements that satisfy @p@.
 takeWhile :: Ord a => (a -> Bool) -> MaxQueue a -> [a]
-takeWhile p (MaxQ q) = coerce (Min.takeWhile (p . unDown) q)
+takeWhile = coerce Min.takeWhile
 
 -- | 'dropWhile' @p queue@ returns the queue remaining after 'takeWhile' @p queue@.
 dropWhile :: Ord a => (a -> Bool) -> MaxQueue a -> MaxQueue a
-dropWhile p (MaxQ q) = MaxQ (Min.dropWhile (p . unDown) q)
+dropWhile = coerce Min.dropWhile
 
 -- | 'span', applied to a predicate @p@ and a queue @queue@, returns a tuple where
 -- first element is longest prefix (possibly empty) of @queue@ of elements that
 -- satisfy @p@ and second element is the remainder of the queue.
 --
 span :: Ord a => (a -> Bool) -> MaxQueue a -> ([a], MaxQueue a)
-span p (MaxQ q) = (coerce xs, MaxQ q') where
-  (xs, q') = Min.span (p . unDown) q
+span = coerce Min.span
 
 -- | 'break', applied to a predicate @p@ and a queue @queue@, returns a tuple where
 -- first element is longest prefix (possibly empty) of @queue@ of elements that
@@ -250,27 +245,25 @@ break p = span (not . p)
 
 -- | \(O(n)\). Returns a queue of those elements which satisfy the predicate.
 filter :: Ord a => (a -> Bool) -> MaxQueue a -> MaxQueue a
-filter p (MaxQ q) = MaxQ (Min.filter (p . unDown) q)
+filter = coerce Min.filter
 
 -- | \(O(n)\). Returns a pair of queues, where the left queue contains those elements that satisfy the predicate,
 -- and the right queue contains those that do not.
 partition :: Ord a => (a -> Bool) -> MaxQueue a -> (MaxQueue a, MaxQueue a)
-partition p (MaxQ q) = (MaxQ q0, MaxQ q1)
-  where  (q0, q1) = Min.partition (p . unDown) q
+partition = coerce Min.partition
 
 -- | \(O(n)\). Maps a function over the elements of the queue, and collects the 'Just' values.
 mapMaybe :: Ord b => (a -> Maybe b) -> MaxQueue a -> MaxQueue b
-mapMaybe f (MaxQ q) = MaxQ (Min.mapMaybe (\(Down x) -> Down <$> f x) q)
+mapMaybe = coerce Min.mapMaybe
 
 -- | \(O(n)\). Maps a function over the elements of the queue, and separates the 'Left' and 'Right' values.
 mapEither :: (Ord b, Ord c) => (a -> Either b c) -> MaxQueue a -> (MaxQueue b, MaxQueue c)
-mapEither f (MaxQ q) = (MaxQ q0, MaxQ q1)
-  where  (q0, q1) = Min.mapEither (either (Left . Down) (Right . Down) . f . unDown) q
+mapEither = coerce Min.mapEither
 
 -- | \(O(n)\). Creates a new priority queue containing the images of the elements of this queue.
 -- Equivalent to @'fromList' . 'Data.List.map' f . toList@.
 map :: Ord b => (a -> b) -> MaxQueue a -> MaxQueue b
-map f (MaxQ q) = MaxQ (Min.map (\(Down x) -> Down (f x)) q)
+map = coerce Min.map
 
 -- | \(O(n)\). Assumes that the function it is given is (weakly) monotonic
 -- (meaning that @x <= y@ implies @f x <= f y@), and
@@ -285,25 +278,25 @@ mapU = mapMonotonic
 
 -- | \(O(n)\). Unordered right fold on a priority queue.
 foldrU :: (a -> b -> b) -> b -> MaxQueue a -> b
-foldrU f z (MaxQ q) = Min.foldrU (flip (foldr f)) z q
+foldrU f z (MaxQ q) = Min.foldrU (coerce f) z q
 
 -- | \(O(n)\). Unordered monoidal fold on a priority queue.
 --
 -- @since 1.4.2
 foldMapU :: Monoid m => (a -> m) -> MaxQueue a -> m
-foldMapU f (MaxQ q) = Min.foldMapU (f . unDown) q
+foldMapU f (MaxQ q) = Min.foldMapU (coerce f) q
 
 -- | \(O(n)\). Unordered left fold on a priority queue. This is rarely
 -- what you want; 'foldrU' and 'foldlU'' are more likely to perform
 -- well.
 foldlU :: (b -> a -> b) -> b -> MaxQueue a -> b
-foldlU f z (MaxQ q) = Min.foldlU (foldl f) z q
+foldlU f z (MaxQ q) = Min.foldlU (coerce f) z q
 
 -- | \(O(n)\). Unordered strict left fold on a priority queue.
 --
 -- @since 1.4.2
 foldlU' :: (b -> a -> b) -> b -> MaxQueue a -> b
-foldlU' f z (MaxQ q) = Min.foldlU' (foldl' f) z q
+foldlU' f z (MaxQ q) = Min.foldlU' (coerce f) z q
 
 {-# INLINE elemsU #-}
 -- | Equivalent to 'toListU'.
@@ -313,7 +306,7 @@ elemsU = toListU
 {-# INLINE toListU #-}
 -- | \(O(n)\). Returns a list of the elements of the priority queue, in no particular order.
 toListU :: MaxQueue a -> [a]
-toListU (MaxQ q) = coerce (Min.toListU q)
+toListU = coerce Min.toListU
 
 -- | \(O(n \log n)\). Performs a right-fold on the elements of a priority queue in ascending order.
 -- @'foldrAsc' f z q == 'foldlDesc' (flip f) z q@.
@@ -327,11 +320,11 @@ foldlAsc = foldrDesc . flip
 
 -- | \(O(n \log n)\). Performs a right-fold on the elements of a priority queue in descending order.
 foldrDesc :: Ord a => (a -> b -> b) -> b -> MaxQueue a -> b
-foldrDesc f z (MaxQ q) = Min.foldrAsc (flip (foldr f)) z q
+foldrDesc f z (MaxQ q) = Min.foldrAsc (coerce f) z q
 
 -- | \(O(n \log n)\). Performs a left-fold on the elements of a priority queue in descending order.
 foldlDesc :: Ord a => (b -> a -> b) -> b -> MaxQueue a -> b
-foldlDesc f z (MaxQ q) = Min.foldlAsc (foldl f) z q
+foldlDesc f z (MaxQ q) = Min.foldlAsc (coerce f) z q
 
 {-# INLINE toAscList #-}
 -- | \(O(n \log n)\). Extracts the elements of the priority queue in ascending order.
@@ -350,26 +343,26 @@ toDescList q = build (\c nil -> foldrDesc c nil q)
 --
 -- If the order of the elements is irrelevant, consider using 'toListU'.
 toList :: Ord a => MaxQueue a -> [a]
-toList (MaxQ q) = coerce (Min.toList q)
+toList = coerce Min.toList
 
 {-# INLINE fromAscList #-}
 -- | \(O(n)\). Constructs a priority queue from an ascending list. /Warning/: Does not check the precondition.
 fromAscList :: [a] -> MaxQueue a
-fromAscList = MaxQ . Min.fromDescList . coerce
+fromAscList = coerce Min.fromDescList
 
 {-# INLINE fromDescList #-}
 -- | \(O(n)\). Constructs a priority queue from a descending list. /Warning/: Does not check the precondition.
 fromDescList :: [a] -> MaxQueue a
-fromDescList = MaxQ . Min.fromAscList . coerce
+fromDescList = coerce Min.fromAscList
 
 {-# INLINE fromList #-}
 -- | \(O(n \log n)\). Constructs a priority queue from an unordered list.
 fromList :: Ord a => [a] -> MaxQueue a
-fromList = MaxQ . Min.fromList . coerce
+fromList = coerce Min.fromList
 
 -- | \(O(n)\). Constructs a priority queue from the keys of a 'Prio.MaxPQueue'.
 keysQueue :: Prio.MaxPQueue k a -> MaxQueue k
-keysQueue (Prio.MaxPQ q) = MaxQ (Min.keysQueue q)
+keysQueue = coerce Min.keysQueue
 
 -- | \(O(\log n)\). @seqSpine q r@ forces the spine of @q@ and returns @r@.
 --


### PR DESCRIPTION
Closes #101.

This probably doesn't change much in the generated code, but at least it's more concise and we can be sure that the conversions get optimized away.