### PR TITLE
Drop GHC 7, allow latest base, random, tasty-bench

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -6,11 +6,11 @@
 #
 #   haskell-ci regenerate
 #
-# For more information, see https://github.com/andreasabel/haskell-ci
+# For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20241219
+# version: 0.19.20250216
 #
-# REGENDATA ("0.19.20241219",["github","pqueue.cabal"])
+# REGENDATA ("0.19.20250216",["github","pqueue.cabal"])
 #
 name: Haskell-CI
 on:
@@ -19,7 +19,7 @@ on:
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes:
       60
     container:
@@ -28,9 +28,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.12.1
+          - compiler: ghc-9.12.2
             compilerKind: ghc
-            compilerVersion: 9.12.1
+            compilerVersion: 9.12.2
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.10.1
@@ -102,13 +102,12 @@ jobs:
       - name: Install GHCup
         run: |
           mkdir -p "$HOME/.ghcup/bin"
-          curl -sL https://downloads.haskell.org/ghcup/0.1.30.0/x86_64-linux-ghcup-0.1.30.0 > "$HOME/.ghcup/bin/ghcup"
+          curl -sL https://downloads.haskell.org/ghcup/0.1.40.0/x86_64-linux-ghcup-0.1.40.0 > "$HOME/.ghcup/bin/ghcup"
           chmod a+x "$HOME/.ghcup/bin/ghcup"
-      - name: Install cabal-install (prerelease)
+      - name: Install cabal-install
         run: |
-          "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.8.yaml;
-          "$HOME/.ghcup/bin/ghcup" install cabal 3.15.0.0.2024.10.3 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.15.0.0.2024.10.3 -vnormal+nowrap" >> "$GITHUB_ENV"
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.12.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.12.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
       - name: Install GHC (GHCup)
         if: matrix.setup-method == 'ghcup'
         run: |
@@ -133,7 +132,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          if [ $((HCNUMVER >= 91200)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
+          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -161,18 +160,6 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
-          if $HEADHACKAGE; then
-          cat >> $CABAL_CONFIG <<EOF
-          repository head.hackage.ghc.haskell.org
-             url: https://ghc.gitlab.haskell.org/head.hackage/
-             secure: True
-             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
-                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
-                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
-             key-threshold: 3
-          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
-          EOF
-          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -224,9 +211,6 @@ jobs:
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           EOF
-          if $HEADHACKAGE; then
-          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
-          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(pqueue)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local

--- a/pqueue.cabal
+++ b/pqueue.cabal
@@ -16,7 +16,7 @@ bug-reports:        https://github.com/lspitzner/pqueue/issues
 build-type:         Simple
 cabal-version:      >= 1.10
 tested-with:
-  GHC == 9.12.1
+  GHC == 9.12.2
   GHC == 9.10.1
   GHC == 9.8.4
   GHC == 9.6.6

--- a/pqueue.cabal
+++ b/pqueue.cabal
@@ -43,7 +43,7 @@ library
   default-language:
     Haskell2010
   build-depends:
-  { base >= 4.8 && < 4.22
+  { base >= 4.9 && < 4.22
   , deepseq >= 1.3 && < 1.6
   , indexed-traversable >= 0.1 && < 0.2
   }
@@ -82,7 +82,7 @@ test-suite test
   type: exitcode-stdio-1.0
   main-is: PQueueTests.hs
   build-depends:
-  { base >= 4.8 && < 4.21
+  { base >= 4.9 && < 4.22
   , deepseq >= 1.3 && < 1.6
   , indexed-traversable >= 0.1 && < 0.2
   , tasty
@@ -126,11 +126,11 @@ benchmark minqueue-benchmarks
     KWay.RandomIncreasing
   ghc-options:      -O2
   build-depends:
-      base          >= 4.8 && < 5
+      base          >= 4.9 && < 5
     , pqueue
     , deepseq       >= 1.3 && < 1.6
-    , random        >= 1.2 && < 1.3
-    , tasty-bench   >= 0.3 && < 0.4
+    , random        >= 1.2 && < 1.4
+    , tasty-bench   >= 0.3 && < 0.5
 
 benchmark minpqueue-benchmarks
   default-language: Haskell2010
@@ -143,8 +143,8 @@ benchmark minpqueue-benchmarks
     KWay.RandomIncreasing
   ghc-options:      -O2
   build-depends:
-      base          >= 4.8 && < 5
+      base          >= 4.9 && < 5
     , pqueue
     , deepseq       >= 1.3 && < 1.6
-    , random        >= 1.2 && < 1.3
-    , tasty-bench   >= 0.3 && < 0.4
+    , random        >= 1.2 && < 1.4
+    , tasty-bench   >= 0.3 && < 0.5

--- a/src/BinomialQueue/Internals.hs
+++ b/src/BinomialQueue/Internals.hs
@@ -50,9 +50,7 @@ import Control.DeepSeq (NFData(rnf), deepseq)
 import Data.Foldable (foldl')
 #endif
 import Data.Function (on)
-#if MIN_VERSION_base(4,9,0)
 import Data.Semigroup (Semigroup(..), stimesMonoid)
-#endif
 
 import Data.PQueue.Internals.Classes
 #ifdef __GLASGOW_HASKELL__
@@ -745,12 +743,10 @@ instance Read a => Read (MinQueue a) where
     return (fromAscList xs,t)
 #endif
 
-#if MIN_VERSION_base(4,9,0)
 instance Ord a => Semigroup (MinQueue a) where
   (<>) = union
   stimes = stimesMonoid
   {-# INLINABLE stimes #-}
-#endif
 
 instance Ord a => Monoid (MinQueue a) where
   mempty = empty

--- a/src/Data/PQueue/Internals.hs
+++ b/src/Data/PQueue/Internals.hs
@@ -51,9 +51,7 @@ import Control.DeepSeq (NFData(rnf), deepseq)
 #if !MIN_VERSION_base(4,20,0)
 import Data.Foldable (foldl')
 #endif
-#if MIN_VERSION_base(4,9,0)
 import Data.Semigroup (Semigroup(..), stimesMonoid)
-#endif
 
 #ifdef __GLASGOW_HASKELL__
 import Data.Data
@@ -376,12 +374,10 @@ instance Read a => Read (MinQueue a) where
     return (fromAscList xs,t)
 #endif
 
-#if MIN_VERSION_base(4,9,0)
 instance Ord a => Semigroup (MinQueue a) where
   (<>) = union
   stimes = stimesMonoid
   {-# INLINABLE stimes #-}
-#endif
 
 instance Ord a => Monoid (MinQueue a) where
   mempty = empty

--- a/src/Data/PQueue/Max.hs
+++ b/src/Data/PQueue/Max.hs
@@ -90,9 +90,7 @@ import Data.Coerce (coerce)
 import Data.Foldable (foldl')
 #endif
 import Data.Maybe (fromMaybe)
-#if MIN_VERSION_base(4,9,0)
 import Data.Semigroup (Semigroup(..), stimesMonoid)
-#endif
 
 import qualified Data.PQueue.Min as Min
 import qualified Data.PQueue.Prio.Max.Internals as Prio
@@ -141,12 +139,10 @@ instance Read a => Read (MaxQueue a) where
     return (fromDescList xs,t)
 #endif
 
-#if MIN_VERSION_base(4,9,0)
 instance Ord a => Semigroup (MaxQueue a) where
   (<>) = union
   stimes = stimesMonoid
   {-# INLINABLE stimes #-}
-#endif
 
 instance Ord a => Monoid (MaxQueue a) where
   mempty = empty

--- a/src/Data/PQueue/Prio/Internals.hs
+++ b/src/Data/PQueue/Prio/Internals.hs
@@ -62,11 +62,7 @@ import Data.Coerce (coerce)
 import Data.Functor.Identity (Identity(Identity, runIdentity))
 import qualified Data.List as List
 
-#if MIN_VERSION_base(4,9,0)
 import Data.Semigroup (Semigroup(..), stimesMonoid, Endo (..), Dual (..))
-#else
-import Data.Monoid ((<>), Endo (..), Dual (..))
-#endif
 
 import Prelude hiding (null, map)
 #ifdef __GLASGOW_HASKELL__
@@ -120,12 +116,10 @@ emptyConstr = mkConstr queueDataType "Empty" [] Prefix
 consConstr  = mkConstr queueDataType ":<" [] Infix
 #endif
 
-#if MIN_VERSION_base(4,9,0)
 instance Ord k => Semigroup (MinPQueue k a) where
   (<>) = union
   stimes = stimesMonoid
   {-# INLINABLE stimes #-}
-#endif
 
 instance Ord k => Monoid (MinPQueue k a) where
   mempty = empty

--- a/src/Data/PQueue/Prio/Max/Internals.hs
+++ b/src/Data/PQueue/Prio/Max/Internals.hs
@@ -111,9 +111,7 @@ import Data.PQueue.Prio.Internals (MinPQueue)
 import qualified Data.PQueue.Prio.Internals as PrioInternals
 import Control.DeepSeq (NFData(rnf))
 
-#if MIN_VERSION_base(4,9,0)
 import Data.Semigroup (Semigroup(..), stimesMonoid)
-#endif
 
 import Prelude hiding (map, filter, break, span, takeWhile, dropWhile, splitAt, take, drop, (!!), null)
 import qualified Data.Foldable as F
@@ -150,12 +148,10 @@ instance (NFData k, NFData a) => NFData (MaxPQueue k a) where
 first' :: (a -> b) -> (a, c) -> (b, c)
 first' f (a, c) = (f a, c)
 
-#if MIN_VERSION_base(4,9,0)
 instance Ord k => Semigroup (MaxPQueue k a) where
   (<>) = union
   stimes = stimesMonoid
   {-# INLINABLE stimes #-}
-#endif
 
 instance Ord k => Monoid (MaxPQueue k a) where
   mempty = empty

--- a/src/Nattish.hs
+++ b/src/Nattish.hs
@@ -21,9 +21,7 @@ module Nattish
 #if __GLASGOW_HASKELL__ >= 904
 import Unsafe.Coerce (unsafeCoerce)
 #endif
-#if __GLASGOW_HASKELL__ >= 800
 import Data.Kind (Type)
-#endif
 
 -- | Conceptually,
 --
@@ -40,11 +38,7 @@ import Data.Kind (Type)
 -- it is very fast to work with.
 
 #if __GLASGOW_HASKELL__ < 904
-#if __GLASGOW_HASKELL__ >= 800
 data Nattish :: k -> (k -> k) -> k -> Type where
-#else
-data Nattish :: k -> (k -> k) -> k -> * where
-#endif
   Zeroy :: Nattish zero succ zero
   Succy :: !(Nattish zero succ n) -> Nattish zero succ (succ n)
 


### PR DESCRIPTION
- Require `base >= 4.9` dropping GHC 7, which can no longer be covered by CI.
- Bump `base`, `random`, `tasty-bench` to latest, allowing GHC 9.12 for all components.