### PR TITLE
Remove `insertBehind`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.7.0.0
 
+* Remove `insertBehind`
+
 * Change `Read` and `Show` instances to use `fromList`
   ([#144](https://github.com/lspitzner/pqueue/issues/144))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.7.0.0
 
-* Remove `insertBehind`
+* Remove `insertBehind` ([#145](https://github.com/lspitzner/pqueue/pull/145))
 
 * Change `Read` and `Show` instances to use `fromList`
   ([#144](https://github.com/lspitzner/pqueue/issues/144))

--- a/src/Data/PQueue/Prio/Internals.hs
+++ b/src/Data/PQueue/Prio/Internals.hs
@@ -17,7 +17,6 @@ module Data.PQueue.Prio.Internals (
   size,
   singleton,
   insert,
-  insertBehind,
   insertEager,
   union,
   getMin,
@@ -234,22 +233,6 @@ insertEager k a Empty = singleton k a
 insertEager k a (MinPQ n k' a' ts)
   | k <= k' = MinPQ (n + 1) k a  (insertEagerHeap k' a' ts)
   | otherwise = MinPQ (n + 1) k' a' (insertEagerHeap k a ts)
-
--- | \(O(n)\) (an earlier implementation had \(O(1)\) but was buggy).
--- Insert an element with the specified key into the priority queue,
--- putting it behind elements whose key compares equal to the
--- inserted one.
-{-# DEPRECATED insertBehind "This function is not reliable." #-}
-insertBehind :: Ord k => k -> a -> MinPQueue k a -> MinPQueue k a
-insertBehind k v q =
-  let (smaller, larger) = spanKey (<= k) q
-  in  foldr (uncurry insert) (insert k v larger) smaller
-
-spanKey :: Ord k => (k -> Bool) -> MinPQueue k a -> ([(k, a)], MinPQueue k a)
-spanKey p q = case minViewWithKey q of
-  Just (t@(k, _), q') | p k ->
-    let (kas, q'') = spanKey p q' in (t : kas, q'')
-  _ -> ([], q)
 
 -- | Amortized \(O(\log \min(n_1,n_2))\), worst-case \(O(\log \max(n_1,n_2))\). Returns the union
 -- of the two specified queues.

--- a/src/Data/PQueue/Prio/Max.hs
+++ b/src/Data/PQueue/Prio/Max.hs
@@ -32,7 +32,6 @@ module Data.PQueue.Prio.Max (
   empty,
   singleton,
   insert,
-  insertBehind,
   union,
   unions,
   -- * Query

--- a/src/Data/PQueue/Prio/Max/Internals.hs
+++ b/src/Data/PQueue/Prio/Max/Internals.hs
@@ -20,7 +20,6 @@ module Data.PQueue.Prio.Max.Internals (
   empty,
   singleton,
   insert,
-  insertBehind,
   union,
   unions,
   -- * Query
@@ -217,14 +216,6 @@ singleton = coerce Q.singleton
 -- an element with the specified key into the queue.
 insert :: Ord k => k -> a -> MaxPQueue k a -> MaxPQueue k a
 insert = coerce Q.insert
-
--- | \(O(n)\) (an earlier implementation had \(O(1)\) but was buggy).
--- Insert an element with the specified key into the priority queue,
--- putting it behind elements whose key compares equal to the
--- inserted one.
-{-# DEPRECATED insertBehind "This function is not reliable." #-}
-insertBehind :: Ord k => k -> a -> MaxPQueue k a -> MaxPQueue k a
-insertBehind = coerce Q.insertBehind
 
 -- | Amortized \(O(\log \min(n_1,n_2))\), worst-case \(O(\log \max(n_1,n_2))\). Returns the union
 -- of the two specified queues.

--- a/src/Data/PQueue/Prio/Min.hs
+++ b/src/Data/PQueue/Prio/Min.hs
@@ -42,7 +42,6 @@ module Data.PQueue.Prio.Min (
   empty,
   singleton,
   insert,
-  insertBehind,
   union,
   unions,
   -- * Query


### PR DESCRIPTION
Resolves #35.

`insertBehind` has been deprecated since 2023 (`pqueue-1.5.0.0`) and we're not even sure if it works correctly. I found no usages on Hackage (https://hackage-search.serokell.io/?q=insertBehind).